### PR TITLE
ci: run all pre-commit hooks on PRs and pushes to main

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -4,8 +4,10 @@ permissions:
   pull-requests: write
 
 on:
+  push:
+    branches: [main]  # run when pushing to main
   pull_request:
-    branches: [main]  # run only for PRs targeting main (merge gate)
+    branches: [main]  # run on PRs targeting main
   workflow_dispatch:
 
 jobs:
@@ -33,13 +35,8 @@ jobs:
             pre-commit-3-${{ runner.os }}-
             pre-commit-3-
 
-      - name: Configure SKIP for non-main (skip Ruff on PRs/branches)
-        run: |
-          if [ "${{ github.event_name }}" != "push" ] || [ "${{ github.ref }}" != "refs/heads/main" ]; then
-            echo "SKIP=no-commit-to-branch,ruff-check,ruff-format" >> "$GITHUB_ENV"
-          else
-            echo "SKIP=no-commit-to-branch" >> "$GITHUB_ENV"
-          fi
+      - name: Configure SKIP for pre-commit hooks
+        run: echo "SKIP=no-commit-to-branch" >> "$GITHUB_ENV"
 
       - name: Run pre-commit using uvx
         run: uvx --with pre-commit-uv pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -15,12 +15,12 @@ repos:
     -   id: mixed-line-ending
 
 -  repo: https://github.com/mwouts/jupytext
-   rev: v1.17.2
+   rev: v1.19.0.dev0
    hooks:
    - id: jupytext
      args: [--sync, pipe]
 -  repo: https://github.com/astral-sh/ruff-pre-commit
-   rev: v0.14.8
+   rev: v0.14.9
    hooks:
    -   id: ruff-check
        types_or: [python, pyi]
@@ -28,14 +28,14 @@ repos:
    -   id: ruff-format
        types_or: [python, pyi]
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.7.20
+  rev: 0.9.18
   hooks:
     - id: pip-compile
       args: [--output-file, requirements.txt, pyproject.toml]
       files: ^pyproject.toml$
       language_version: python3.11
 - repo: https://github.com/compilerla/conventional-pre-commit
-  rev: v4.2.0
+  rev: v4.3.0
   hooks:
     - id: conventional-pre-commit
       stages: [commit-msg]


### PR DESCRIPTION
## Summary
- Simplified pre-commit workflow to run all hooks (including ruff) on every trigger
- Workflow now runs on pushes to main and PRs targeting main
- Removed conditional skip logic that was preventing ruff from running

🤖 Generated with [Claude Code](https://claude.com/claude-code)