### PR TITLE
chore: create the GitHub release after the PyPI release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,12 @@ jobs:
       - name: Remove pre-existing publish attestations
         run: rm -f dist/*.publish.attestation
 
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        with:
+          print-hash: true
+          attestations: true
+          
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
@@ -58,11 +64,5 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
-        with:
-          print-hash: true
-          attestations: true
 
       - run: rm -f RELEASE_NOTES.md


### PR DESCRIPTION
If the PyPI workflow fails, the github release is canceled