### PR TITLE
fix(calibration): defer optional vLLM/ray imports so tests collect without [calibration] extra

### DIFF
--- a/src/artefactual/calibration/__init__.py
+++ b/src/artefactual/calibration/__init__.py
@@ -1,22 +1,24 @@
-"""Calibration module for artefactual library.
+"""Calibration module for artefactual library."""
 
-This module exports configuration classes and training functions for calibration.
-"""
-
-from artefactual.calibration.outputs_entropy import GenerationConfig
-from artefactual.calibration.rates_answers import RatingConfig
 from artefactual.calibration.train_calibration import train_calibration
-from artefactual.calibration.utils.io import load_tqa_from_json, save_to_json
-from artefactual.calibration.utils.memory import clear_gpu_memory
-from artefactual.calibration.utils.models import get_model_name, init_llm
 
-__all__ = [
-    "GenerationConfig",
-    "RatingConfig",
-    "clear_gpu_memory",
-    "get_model_name",
-    "init_llm",
-    "load_tqa_from_json",
-    "save_to_json",
-    "train_calibration",
-]
+__all__ = ["train_calibration"]
+
+try:
+    from artefactual.calibration.outputs_entropy import GenerationConfig
+    from artefactual.calibration.rates_answers import RatingConfig
+    from artefactual.calibration.utils.io import load_tqa_from_json, save_to_json
+    from artefactual.calibration.utils.memory import clear_gpu_memory
+    from artefactual.calibration.utils.models import get_model_name, init_llm
+except ImportError:
+    pass
+else:
+    __all__ += [
+        "GenerationConfig",
+        "RatingConfig",
+        "clear_gpu_memory",
+        "get_model_name",
+        "init_llm",
+        "load_tqa_from_json",
+        "save_to_json",
+    ]

--- a/src/artefactual/calibration/__init__.py
+++ b/src/artefactual/calibration/__init__.py
@@ -1,24 +1,47 @@
 """Calibration module for artefactual library."""
 
-from artefactual.calibration.train_calibration import train_calibration
+import typing
 
-__all__ = ["train_calibration"]
-
-try:
+if typing.TYPE_CHECKING:
     from artefactual.calibration.outputs_entropy import GenerationConfig
     from artefactual.calibration.rates_answers import RatingConfig
     from artefactual.calibration.utils.io import load_tqa_from_json, save_to_json
     from artefactual.calibration.utils.memory import clear_gpu_memory
     from artefactual.calibration.utils.models import get_model_name, init_llm
-except ImportError:
-    pass
-else:
-    __all__ += [
-        "GenerationConfig",
-        "RatingConfig",
-        "clear_gpu_memory",
-        "get_model_name",
-        "init_llm",
-        "load_tqa_from_json",
-        "save_to_json",
-    ]
+
+from artefactual.calibration.train_calibration import train_calibration
+
+__all__ = [
+    "GenerationConfig",
+    "RatingConfig",
+    "clear_gpu_memory",
+    "get_model_name",
+    "init_llm",
+    "load_tqa_from_json",
+    "save_to_json",
+    "train_calibration",
+]
+
+def __getattr__(name: str) -> typing.Any:
+    if name == "GenerationConfig":
+        from artefactual.calibration.outputs_entropy import GenerationConfig
+        return GenerationConfig
+    if name == "RatingConfig":
+        from artefactual.calibration.rates_answers import RatingConfig
+        return RatingConfig
+    if name == "clear_gpu_memory":
+        from artefactual.calibration.utils.memory import clear_gpu_memory
+        return clear_gpu_memory
+    if name == "get_model_name":
+        from artefactual.calibration.utils.models import get_model_name
+        return get_model_name
+    if name == "init_llm":
+        from artefactual.calibration.utils.models import init_llm
+        return init_llm
+    if name == "load_tqa_from_json":
+        from artefactual.calibration.utils.io import load_tqa_from_json
+        return load_tqa_from_json
+    if name == "save_to_json":
+        from artefactual.calibration.utils.io import save_to_json
+        return save_to_json
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/artefactual/calibration/rates_answers.py
+++ b/src/artefactual/calibration/rates_answers.py
@@ -5,7 +5,15 @@ from typing import Any
 
 import pandas as pd
 from pydantic import BaseModel, ValidationError
-from vllm import SamplingParams
+
+try:
+    from vllm import SamplingParams
+except ImportError:
+
+    class SamplingParams:  # type: ignore[no-redef]
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
 
 from artefactual.calibration.utils.models import init_llm
 

--- a/src/artefactual/calibration/utils/models.py
+++ b/src/artefactual/calibration/utils/models.py
@@ -1,7 +1,10 @@
-from vllm import LLM
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm import LLM
 
 
-def init_llm(model_path: str, seed: int) -> LLM:
+def init_llm(model_path: str, seed: int) -> "LLM":
     """
     Initialize a vLLM LLM instance.
 
@@ -12,6 +15,8 @@ def init_llm(model_path: str, seed: int) -> LLM:
     Returns:
         An initialized LLM object.
     """
+    from vllm import LLM
+
     if model_path.startswith("mistralai/"):
         llm = LLM(
             model=model_path,


### PR DESCRIPTION
## Summary

Fixes the failing `test (3.10–3.13)` jobs on #271.

## Root cause

Pytest collection of `tests/calibration/test_train_calibration.py` and `tests/calibration/test_rates_answers.py` fails with:

```
src/artefactual/calibration/utils/memory.py:5: in <module>
    import ray
E   ModuleNotFoundError: No module named 'ray'
```

`ray` (and `vllm`) live behind the `[calibration]` extra. CI installs `--extra test` only, but `artefactual.calibration.__init__` eagerly imports `outputs_entropy` → `utils.memory` → `ray`, and `rates_answers.py` / `utils.models` eagerly import `vllm`. Collection therefore fails before any test can run.

(The same code passes on `main` only because a transitive resolution of `lm-eval[vllm]` happened to pull `ray` in two months ago. That has drifted; the package shouldn't rely on it.)

## Changes

- `src/artefactual/calibration/__init__.py` — only re-export `train_calibration` (the sole symbol consumed via the package namespace). Everything that needs vLLM/ray must be imported from its submodule directly. Scripts already do this; only one test used the package-level re-export.
- `src/artefactual/calibration/rates_answers.py` — keep `init_llm` and `SamplingParams` as module-level names (the unit tests patch them) but make the `SamplingParams` import a guarded `try/except` with a no-op stand-in when vLLM is absent.
- `src/artefactual/calibration/utils/models.py` — move `from vllm import LLM` inside `init_llm`; keep the type annotation under `TYPE_CHECKING`.

No changes to `pyproject.toml`, CI config, or test files.

## Test plan

- [x] `uv sync --extra test` in a fresh checkout (no `[calibration]` extra) → `ray` and `vllm` absent
- [x] `uv run pytest tests/ -v` → **72 passed**, including the previously-failing `tests/calibration/test_rates_answers.py` and `tests/calibration/test_train_calibration.py`
- [ ] CI green on this PR