### PR TITLE
fix(scoring): raise ValueError for unknown reduction strategy instead of KeyError

### DIFF
--- a/src/artefactual/scoring/entropy_methods/entropy_transformer.py
+++ b/src/artefactual/scoring/entropy_methods/entropy_transformer.py
@@ -42,7 +42,12 @@ class EntropyTransformer(BaseEstimator, TransformerMixin, EntropyContributionsMi
     @property
     def reduction_fn(self) -> Callable:
         # self.reduction must stay unchanged for clone/get_params/set_params.
-        return self.reduction if callable(self.reduction) else STRATEGIES[self.reduction]
+        if callable(self.reduction):
+            return self.reduction
+        if self.reduction in STRATEGIES:
+            return STRATEGIES[self.reduction]
+        msg = f"Invalid reduction: {self.reduction!r}. Expected 'epr', 'wepr', or a callable."
+        raise ValueError(msg)
 
     def transform(self, x: np.ndarray) -> np.ndarray:  # (n, n_features)
         s_kj = self.entropy_contributions(x)

--- a/tests/scoring/entropic_methods/test_entropy_transformer.py
+++ b/tests/scoring/entropic_methods/test_entropy_transformer.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from artefactual.scoring.entropy_methods.entropy_transformer import EntropyTransformer
+
+# (n_sequences, n_tokens, k) log-probabilities, descending along the rank axis
+LOGPROBS = np.array([[[-0.1, -2.0, -3.0], [-0.5, -1.5, -4.0]]])
+
+
+@pytest.mark.parametrize("reduction", ["epr", "wepr"])
+def test_known_reductions_transform(reduction):
+    features = EntropyTransformer(reduction=reduction).transform(LOGPROBS)
+    assert features.shape[0] == LOGPROBS.shape[0]
+    assert np.isfinite(features).all()
+
+
+def test_callable_reduction_is_used_as_is():
+    features = EntropyTransformer(reduction=lambda x, axis: np.nanmean(x, axis=axis)).transform(LOGPROBS)
+    assert features.shape[0] == LOGPROBS.shape[0]
+
+
+def test_unknown_reduction_raises_value_error():
+    with pytest.raises(ValueError, match="Invalid reduction: 'bogus'"):
+        EntropyTransformer(reduction="bogus").transform(LOGPROBS)
+
+
+def test_unknown_reduction_error_names_the_valid_options():
+    with pytest.raises(ValueError, match="Expected 'epr', 'wepr', or a callable"):
+        EntropyTransformer(reduction="mean").transform(LOGPROBS)
+
+
+def test_reduction_parameter_is_not_mutated():
+    # get_params/set_params/clone require constructor args to survive untouched
+    transformer = EntropyTransformer(reduction="wepr")
+    transformer.transform(LOGPROBS)
+    assert transformer.reduction == "wepr"
+    assert transformer.get_params()["reduction"] == "wepr"


### PR DESCRIPTION
## Summary

`EntropyTransformer.reduction_fn` indexed `STRATEGIES` directly, so an unrecognised `reduction` surfaced as `KeyError: 'bogus'`. scikit-learn's contract is that invalid parameter *values* raise `ValueError`, and `check_estimator` asserts it — so this is a prerequisite for #245.

```python
>>> EntropyTransformer(reduction="bogus").transform(x)
ValueError: Invalid reduction: 'bogus'. Expected 'epr', 'wepr', or a callable.
```

## Provenance

Salvaged from `8cb19ed8` on `issue-277-242-Exceptions-EntropyTransformer`. That commit was written in response to the review on #287, which asked for exactly this ("validating the `reduction` parameter to raise a clear `ValueError` instead of a `KeyError`") — but #287 was closed two seconds after #286 merged, superseded before the review fix ever landed. The source change here is byte-identical to `8cb19ed8`; it is **not** a file-level restore, which would have reintroduced the `k` parameter that #291's `d2e68d7` removed.

The branch it came from carries no other unique work and is slated for deletion.

## Tests

`EntropyTransformer` had **no test file at all** before this. Added `tests/scoring/entropic_methods/test_entropy_transformer.py` — real arrays, no mocks — covering both reductions, the callable path, both error cases, and non-mutation of `reduction` (required for `clone`/`get_params`).

Verified non-vacuous: against `main`'s code the two error tests fail with `KeyError: 'bogus'` / `KeyError: 'mean'`.

- `pytest`: 85 passed (79 on main + 6 new)
- `pre-commit run --all-files`: all 15 hooks pass

Refs #245. Does not close any issue on its own.
