### PR TITLE
feat(preprocessing)!: parse response batches, validate payloads with pydantic, deprecate vLLM parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Artefactual is a lightweight Python package for measuring model hallucination risk using entropy-based metrics. It is:
 
 - **Practical**: Precomputed calibration for several model families is included in `src/artefactual/data` and can be used by model name.
-- **Flexible**: Works with vLLM, OpenAI Chat Completions, and the OpenAI Responses API formats.
+- **Flexible**: Works with OpenAI Chat Completions and OpenAI Responses payloads, as objects or plain mappings, one at a time or as a batch.
 - **Detailed outputs**: Compute both sequence-level and token-level uncertainty scores to power downstream pipelines (e.g., answer filtering, reranking, human-in-the-loop triggers).
 
 The package provides two primary uncertainty detectors:
@@ -30,9 +30,9 @@ uv pip install -e '.[calibration]'
 # or non-editable:
 uv pip install '.[calibration]'
 ```
-*Mac users:* the calibration extra omits vllm (no Darwin wheels). Running the full calibration pipeline on Mac requires an alternative generation backend.
+*Mac users:* the calibration extra omits the GPU generation backend (no Darwin wheels). Running the full calibration pipeline on Mac requires an alternative generation backend.
 
-*Note*: Typical packages included in this installation method are `scikit-learn` (training), `vllm` (model generation), `ray` (optional distributed processing), `pandas`, `numpy`, and `tqdm`. Installing these may require system-level libraries or CUDA support depending on your environment.
+*Note*: Typical packages included in this installation method are `scikit-learn` (training), a local generation backend, `ray` (optional distributed processing), `pandas`, `numpy`, and `tqdm`. Installing these may require system-level libraries or CUDA support depending on your environment.
 
 ## Quickstart
 
@@ -56,7 +56,7 @@ from artefactual.scoring import EPR
 epr = EPR(pretrained_model_name_or_path="mistralai/Ministral-8B-Instruct-2410")
 
 # Compute sequence-level calibrated probabilities (list of floats)
-parsed_logprobs = parse_top_logprobs(response)  # response should be your OpenAI/vLLM output object
+parsed_logprobs = parse_top_logprobs(response)  # an OpenAI completion response, or a list of them
 seq_scores_epr = epr.compute(parsed_logprobs)
 
 # Compute token-level scores (list of numpy arrays)
@@ -76,7 +76,7 @@ from artefactual.scoring import WEPR
 wepr = WEPR(pretrained_model_name_or_path="mistralai/Ministral-8B-Instruct-2410")
 
 # Compute sequence-level calibrated probabilities (list of floats)
-parsed_logprobs = parse_top_logprobs(response) # response should be your OpenAI/vLLM output object
+parsed_logprobs = parse_top_logprobs(response)  # an OpenAI completion response, or a list of them
 seq_scores_wepr = wepr.compute(parsed_logprobs)
 
 # Compute token-level scores (list of numpy arrays)

--- a/examples/epr_usage_demo.py
+++ b/examples/epr_usage_demo.py
@@ -2,22 +2,22 @@ from pathlib import Path
 
 from mock_vllm import load_json
 
-from artefactual.preprocessing import parse_top_logprobs
+from artefactual.preprocessing import parse_top_logprobs, process_vllm_top_logprobs
 from artefactual.scoring import EPR, WEPR
 
 
-def mock_vllm_example() -> None:
+def recorded_outputs_example() -> None:
     # ==========================================
-    # OPTION 1: Mocked vLLM Example
+    # OPTION 1: Recorded generation outputs
     # ==========================================
 
     fixture_path = Path(__file__).parent / "wepr_demo_responses.json"
-    print(f"Loading mock vLLM data from {fixture_path}...")  # noqa: T201
+    print(f"Loading recorded outputs from {fixture_path}...")  # noqa: T201
     outputs = load_json(fixture_path)
 
     # Compute EPR
     epr = EPR()  # initialize with default calibration
-    parsed_logprobs = parse_top_logprobs(outputs)  # parse the outputs to get logprobs
+    parsed_logprobs = process_vllm_top_logprobs(outputs, iterations=1)  # recorded outputs, not a completion response
 
     scores = epr.compute(parsed_logprobs)
     print(f"EPR Scores: {scores}")  # noqa: T201
@@ -91,5 +91,5 @@ def openai_example() -> None:
 
 
 if __name__ == "__main__":
-    mock_vllm_example()
+    recorded_outputs_example()
     openai_example()

--- a/examples/wepr_demo.ipynb
+++ b/examples/wepr_demo.ipynb
@@ -14,8 +14,8 @@
     "2.  **Hallucination Trigger**: Asking about the first author of our paper (Charles Moslonka) to observe how the model hallucinates biographical details (expected higher entropy/uncertainty).\n",
     "\n",
     "We will use:\n",
-    "*   `Mock Dataclasses` contained in mock_vllm.py, which mimic the subset of vLLM's RequestOutput that process_vllm_top_logprobs and vllm_sampled_tokens_logprobs actually touch to avoid the use of a GPU for the demo \n",
-    "* `JSON fixture (wepr_demo_responses.json)` containing responses from Falcon3-10B-Instruct which is processed through mock_vllm.py\n",
+    "*   `Mock Dataclasses` contained in mock_vllm.py, which mimic the subset of the recorded generation output the parsing helpers actually touch, to avoid the use of a GPU for the demo \n",
+    "* `JSON fixture (wepr_demo_responses.json)` containing recorded responses from Falcon3-10B-Instruct, replayed through mock_vllm.py\n",
     "* `Local Weight Fixture (weights_falcon3.json)` that provides the coefficients used to decide if that data seems to be a hallucination or not for the scorer, replacing the need to load the full model\n",
     "*   `WEPR` (Weighted EPR) scorer from the `artefactual` package to quantify the uncertainty of the generated sequences.\n",
     "*   Visualizations to inspect token-level scores, highlighting potentially hallucinated segments."
@@ -35,7 +35,7 @@
     "from IPython.display import HTML, display\n",
     "from mock_vllm import load_json\n",
     "\n",
-    "from artefactual.preprocessing import parse_top_logprobs\n",
+    "from artefactual.preprocessing import process_vllm_top_logprobs\n",
     "from artefactual.scoring import WEPR"
    ]
   },
@@ -145,7 +145,10 @@
    "source": [
     "### Instantiate the WEPR scorer\n",
     "\n",
-    "First parse the output with the `parse_top_logprobs` function.\n",
+    "First parse the recorded outputs with `process_vllm_top_logprobs`.\n",
+    "\n",
+    "For completion responses from an API, use `parse_top_logprobs` instead — it takes a\n",
+    "single response or a list of them.\n",
     "\n",
     "Then pass the logprobs directly to the `scorer.compute()` method."
    ]
@@ -181,7 +184,7 @@
    "source": [
     "scorer = WEPR(pretrained_model_name_or_path=\"weights_falcon3.json\")\n",
     "\n",
-    "processed_prompts_1 = parse_top_logprobs(outputs1)\n",
+    "processed_prompts_1 = process_vllm_top_logprobs(outputs1, iterations=1)\n",
     "wepr_scores_1 = scorer.compute(processed_prompts_1)\n",
     "print(f\"WEPR Sequence Score for the first output: {wepr_scores_1}\")\n",
     "print(\"\\n\")\n",
@@ -190,7 +193,7 @@
     "print(\"\\n\")\n",
     "print(\"*\" * 40)\n",
     "print(\"\\n\")\n",
-    "processed_prompts_2 = parse_top_logprobs(outputs2)\n",
+    "processed_prompts_2 = process_vllm_top_logprobs(outputs2, iterations=1)\n",
     "wepr_scores_2 = scorer.compute(processed_prompts_2)\n",
     "print(f\"WEPR Sequence Score for the second output: {wepr_scores_2}\")\n",
     "print(\"\\n\")\n",

--- a/src/artefactual/preprocessing/parser.py
+++ b/src/artefactual/preprocessing/parser.py
@@ -3,24 +3,61 @@ Module for parsing model outputs from various sources to extract log probabiliti
 Each format is handled by a dedicated parser function, defined in their respective modules.
 """
 
+import warnings
+from functools import singledispatch
 from typing import Any
 
 import numpy as np
+from beartype.door import is_bearable
 from numpy.typing import NDArray
+from pydantic import TypeAdapter, ValidationError
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import Tags
 
 from artefactual.preprocessing.openai_parser import (
-    is_openai_responses_api,
     process_openai_chat_completion,
     process_openai_responses_api,
     sampled_tokens_logprobs_chat_completion_api,
     sampled_tokens_logprobs_responses_api,
 )
-from artefactual.preprocessing.vllm_parser import (
-    process_vllm_top_logprobs,
-    vllm_sampled_tokens_logprobs,
-)
+from artefactual.preprocessing.response_models import ChatCompletion, ResponsesPayload
+from artefactual.preprocessing.vllm_parser import _VLLM_DEPRECATION, vllm_sampled_tokens_logprobs
+
+_RESPONSE_ADAPTER = TypeAdapter(ChatCompletion | ResponsesPayload)
+
+
+@singledispatch
+def _top_logprobs(response: Any) -> list[dict[int, list[float]]]:
+    """Extract per-token top logprobs from a validated response. Register one per format."""
+    msg = f"No top-logprob extractor registered for {type(response).__name__}."
+    raise TypeError(msg)
+
+
+@_top_logprobs.register
+def _(response: ChatCompletion) -> list[dict[int, list[float]]]:
+    return process_openai_chat_completion(response, iterations=len(response.choices))
+
+
+@_top_logprobs.register
+def _(response: ResponsesPayload) -> list[dict[int, list[float]]]:
+    return process_openai_responses_api(response)
+
+
+@singledispatch
+def _sampled_logprobs(response: Any) -> list[NDArray]:
+    """Extract sampled-token logprobs from a validated response. Register one per format."""
+    msg = f"No sampled-logprob extractor registered for {type(response).__name__}."
+    raise TypeError(msg)
+
+
+@_sampled_logprobs.register
+def _(response: ChatCompletion) -> list[NDArray]:
+    return sampled_tokens_logprobs_chat_completion_api(response)
+
+
+@_sampled_logprobs.register
+def _(response: ResponsesPayload) -> list[NDArray]:
+    return sampled_tokens_logprobs_responses_api(response)
 
 
 class LogProbParser(BaseEstimator, TransformerMixin):
@@ -79,37 +116,26 @@ def parse_top_logprobs(outputs: Any) -> list[dict[int, list[float]]]:
 
     Args:
         outputs: Model outputs. Can be:
-                    - List of vLLM RequestOutput objects.
-                    - OpenAI ChatCompletion object (or dict).
-                    - OpenAI Responses object (or dict).
+                    - A completion response, as a mapping or an object.
+                    - A sequence of responses, parsed and concatenated in order.
 
     Returns:
-        List of dictionaries mapping token indices to lists of log probs.
+        List of dictionaries mapping token indices to lists of log probs,
+        one per generated sequence.
 
     Raises:
         TypeError: If the output format is not supported.
     """
-    # vLLM parser
-    if isinstance(outputs, list) and len(outputs) > 0 and hasattr(outputs[0], "outputs"):
-        if not outputs[0].outputs:
-            return []
-        iterations = len(outputs[0].outputs)
-        return process_vllm_top_logprobs(outputs, iterations)
+    if is_bearable(outputs, list | tuple):
+        return [sequence for response in outputs for sequence in parse_top_logprobs(response)]
 
-    # OpenAI parser for classic ChatCompletion
-    if hasattr(outputs, "choices") or (isinstance(outputs, dict) and "choices" in outputs):
-        choices = outputs.choices if hasattr(outputs, "choices") else outputs["choices"]
-        return process_openai_chat_completion(outputs, iterations=len(choices))
+    try:
+        response = _RESPONSE_ADAPTER.validate_python(outputs, from_attributes=True)
+    except ValidationError as error:
+        msg = f"Unsupported output format: {type(outputs).__name__}. Expected a completion response carrying logprobs."
+        raise TypeError(msg) from error
 
-    # OpenAI parser for Responses API
-    if is_openai_responses_api(outputs):
-        return process_openai_responses_api(outputs)
-
-    msg = (
-        f"Unsupported output format: {type(outputs).__name__}. "
-        "Expected vLLM RequestOutput, OpenAI ChatCompletion, or OpenAI Responses object."
-    )
-    raise TypeError(msg)
+    return _top_logprobs(response)
 
 
 def parse_sampled_token_logprobs(outputs: Any) -> list[NDArray]:
@@ -123,23 +149,18 @@ def parse_sampled_token_logprobs(outputs: Any) -> list[NDArray]:
         list[NDArray]: A list of 1D numpy arrays, each containing the log probabilities
                        of the sampled tokens for one sequence.
     """
-    # Check for vLLM offline inference format
+    # Deprecated vLLM offline inference format
     if isinstance(outputs, list) and len(outputs) > 0 and hasattr(outputs[0], "outputs"):
+        warnings.warn(_VLLM_DEPRECATION, DeprecationWarning, stacklevel=2)
         if not outputs[0].outputs:
             return []
         iterations = len(outputs[0].outputs)
         return vllm_sampled_tokens_logprobs(outputs, iterations)
 
-    # Check for OpenAI ChatCompletion format
-    if hasattr(outputs, "choices") or (isinstance(outputs, dict) and "choices" in outputs):
-        return sampled_tokens_logprobs_chat_completion_api(outputs)
+    try:
+        response = _RESPONSE_ADAPTER.validate_python(outputs, from_attributes=True)
+    except ValidationError as error:
+        msg = f"Unsupported output format: {type(outputs).__name__}. Expected a completion response carrying logprobs."
+        raise TypeError(msg) from error
 
-    # Check for OpenAI Responses API format
-    if is_openai_responses_api(outputs):
-        return sampled_tokens_logprobs_responses_api(outputs)
-
-    msg = (
-        f"Unsupported output format: {type(outputs).__name__}. "
-        "Expected vLLM RequestOutput, OpenAI ChatCompletion, or OpenAI Responses object."
-    )
-    raise TypeError(msg)
+    return _sampled_logprobs(response)

--- a/src/artefactual/preprocessing/response_models.py
+++ b/src/artefactual/preprocessing/response_models.py
@@ -1,0 +1,66 @@
+"""Typed models for the completion formats the parsers consume.
+
+Only the logprob path is modelled; `extra="ignore"` drops the rest of the payload.
+`from_attributes=True` accepts both a raw mapping and an attribute-style object.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+_ACCEPTS_DICT_OR_OBJECT = ConfigDict(from_attributes=True, extra="ignore")
+
+
+class TopLogprob(BaseModel):
+    """One rank of the top-k distribution for a single token."""
+
+    model_config = _ACCEPTS_DICT_OR_OBJECT
+
+    logprob: float | None = None
+
+
+class TokenLogprobs(BaseModel):
+    """One generated token, with the top-k alternatives considered at that position."""
+
+    model_config = _ACCEPTS_DICT_OR_OBJECT
+
+    logprob: float | None = None
+    top_logprobs: list[TopLogprob] = []
+
+
+class ChatChoiceLogprobs(BaseModel):
+    model_config = _ACCEPTS_DICT_OR_OBJECT
+
+    content: list[TokenLogprobs] = []
+
+
+class ChatChoice(BaseModel):
+    model_config = _ACCEPTS_DICT_OR_OBJECT
+
+    logprobs: ChatChoiceLogprobs | None = None
+
+
+class ChatCompletion(BaseModel):
+    """`client.chat.completions.create(...)` — one `choice` per sampled sequence."""
+
+    model_config = _ACCEPTS_DICT_OR_OBJECT
+
+    choices: list[ChatChoice]
+
+
+class ResponseContentPart(BaseModel):
+    model_config = _ACCEPTS_DICT_OR_OBJECT
+
+    logprobs: list[TokenLogprobs] = []
+
+
+class ResponseOutputItem(BaseModel):
+    model_config = _ACCEPTS_DICT_OR_OBJECT
+
+    content: list[ResponseContentPart] = []
+
+
+class ResponsesPayload(BaseModel):
+    """`client.responses.create(...)` — one `output` item per sampled sequence."""
+
+    model_config = _ACCEPTS_DICT_OR_OBJECT
+
+    output: list[ResponseOutputItem]

--- a/src/artefactual/preprocessing/vllm_parser.py
+++ b/src/artefactual/preprocessing/vllm_parser.py
@@ -1,4 +1,5 @@
 import operator
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -7,10 +8,20 @@ from numpy.typing import NDArray
 if TYPE_CHECKING:
     from vllm import RequestOutput
 
+_VLLM_DEPRECATION = (
+    "vLLM-specific parsing is deprecated and will be removed in a future release: "
+    "artefactual targets standard completion responses rather than inference-server "
+    "formats. Convert vLLM outputs to a completion response before parsing."
+)
+
 
 def process_vllm_top_logprobs(outputs: list["RequestOutput"], iterations: int) -> list[dict[int, list[float]]]:
     """
     Processes log probabilities from vllm `LLM.generate` (or `chat`) outputs for a given number of iterations.
+
+    .. deprecated::
+        Unreachable from `parse_top_logprobs`, which now only accepts standard completion
+        responses. Kept for direct callers until removal.
 
     Args:
         outputs (list[RequestOutput]): A list containing model output objects, each with log probability data.
@@ -19,6 +30,7 @@ def process_vllm_top_logprobs(outputs: list["RequestOutput"], iterations: int) -
         list[dict[int, list[float]]]: A list of dictionaries mapping token indices to lists of log probs
         for each token in the sequence.
     """
+    warnings.warn(_VLLM_DEPRECATION, DeprecationWarning, stacklevel=2)
 
     if not outputs or not outputs[0].outputs:
         return []

--- a/src/artefactual/scoring/entropy_methods/entropy_contributions.py
+++ b/src/artefactual/scoring/entropy_methods/entropy_contributions.py
@@ -33,3 +33,29 @@ class EntropyContributionsMixin:
         # Calculate entropy contributions: s = -p * log(p) = -exp(logp) * logp (logprobs are natural logs)
         with np.errstate(divide="ignore", invalid="ignore"):
             return -probs * logprobs
+
+
+@beartype
+def align_rank_width(contributions: NDArray[np.floating], k: int) -> NDArray[np.floating]:
+    """Truncate or zero-pad entropy contributions to exactly `k` ranks.
+
+    Calibrated weights are fixed at the rank count used during calibration, so the rank
+    axis must match before the weighted sum. Zero is the limit of the contribution itself
+    -- -p*log(p) tends to 0 as p tends to 0 -- so absent ranks add nothing to the score.
+
+    Args:
+        contributions: Array of shape (num_tokens, num_ranks).
+        k: Number of ranks the calibrated weights expect.
+
+    Returns:
+        Array of shape (num_tokens, k).
+    """
+    num_tokens, num_ranks = contributions.shape
+    if num_ranks == k:
+        return contributions
+    if num_ranks > k:
+        return contributions[:, :k]
+
+    aligned = np.zeros((num_tokens, k), dtype=contributions.dtype)
+    aligned[:, :num_ranks] = contributions
+    return aligned

--- a/src/artefactual/scoring/entropy_methods/epr.py
+++ b/src/artefactual/scoring/entropy_methods/epr.py
@@ -6,7 +6,7 @@ from beartype import beartype
 from numpy.typing import NDArray
 
 from artefactual.data.data_model import Completion
-from artefactual.scoring.entropy_methods.entropy_contributions import EntropyContributionsMixin
+from artefactual.scoring.entropy_methods.entropy_contributions import EntropyContributionsMixin, align_rank_width
 from artefactual.scoring.uncertainty_detector import LogProbUncertaintyDetector
 from artefactual.utils.io import load_calibration
 
@@ -89,7 +89,8 @@ class EPR(LogProbUncertaintyDetector):
             logprobs_list = [token_logprobs_dict[i] for i in sorted_indices]
 
             # Vectorized Entropy Calculation
-            s_kj = EntropyContributionsMixin.entropy_contributions(logprobs_list, self.k)
+            contributions = EntropyContributionsMixin.entropy_contributions(np.asarray(logprobs_list))
+            s_kj = align_rank_width(contributions, self.k)
 
             # sum over rank K (Token EPR)
             token_epr = np.sum(s_kj, axis=1)  # shape = (num_tokens_in_sequence)

--- a/src/artefactual/scoring/entropy_methods/wepr.py
+++ b/src/artefactual/scoring/entropy_methods/wepr.py
@@ -5,7 +5,7 @@ from beartype import beartype
 from numpy.typing import NDArray
 
 from artefactual.data.data_model import Completion
-from artefactual.scoring.entropy_methods.entropy_contributions import EntropyContributionsMixin
+from artefactual.scoring.entropy_methods.entropy_contributions import EntropyContributionsMixin, align_rank_width
 from artefactual.scoring.uncertainty_detector import LogProbUncertaintyDetector
 from artefactual.utils.io import load_weights
 
@@ -82,7 +82,8 @@ class WEPR(LogProbUncertaintyDetector):
 
             # Compute entropy contributions in a vectorized manner
             # Input shape: (num_tokens_in_sequence, K)
-            s_kj = EntropyContributionsMixin.entropy_contributions(logprobs_list, self.k)
+            contributions = EntropyContributionsMixin.entropy_contributions(np.asarray(logprobs_list))
+            s_kj = align_rank_width(contributions, self.k)
 
             # Token-level WEPR (S_beta): weighted sum across K using mean_weights
             # S_beta = sum(beta_k * s_kj) + beta_0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,57 @@
-import importlib.util
+from beartype.door import is_bearable
+from hypothesis import strategies as st
 
-import pytest
+from artefactual.preprocessing.response_models import (
+    ChatChoice,
+    ChatChoiceLogprobs,
+    ChatCompletion,
+    ResponseContentPart,
+    ResponseOutputItem,
+    ResponsesPayload,
+    TokenLogprobs,
+    TopLogprob,
+)
 
-VLLM_INSTALLED = importlib.util.find_spec("vllm") is not None
+# Payloads are built from the response models themselves, so a change to the models
+# changes what the tests generate — the shapes cannot drift apart.
+
+# logprobs are <= 0 and finite; the parser rejects anything else
+logprob_values = st.floats(min_value=-25.0, max_value=0.0, allow_nan=False, allow_infinity=False)
+
+top_logprobs = st.lists(st.builds(TopLogprob, logprob=logprob_values), min_size=1, max_size=8)
+
+token_logprobs = st.builds(
+    lambda ranks: TokenLogprobs(logprob=ranks[0].logprob, top_logprobs=ranks),
+    top_logprobs,
+)
+
+# ragged token counts within a sequence
+token_sequences = st.lists(token_logprobs, min_size=1, max_size=6)
+
+chat_completions = st.builds(
+    ChatCompletion,
+    choices=st.lists(
+        st.builds(ChatChoice, logprobs=st.builds(ChatChoiceLogprobs, content=token_sequences)),
+        min_size=1,
+        max_size=4,
+    ),
+)
+
+responses_api = st.builds(
+    ResponsesPayload,
+    output=st.lists(
+        st.builds(
+            ResponseOutputItem,
+            content=st.lists(st.builds(ResponseContentPart, logprobs=token_sequences), min_size=1, max_size=1),
+        ),
+        min_size=1,
+        max_size=4,
+    ),
+)
+
+openai_payloads = st.one_of(chat_completions, responses_api)
 
 
-def pytest_configure(config):
-    config.addinivalue_line("markers", "vllm: mark test as requiring vllm")
-
-
-def pytest_collection_modifyitems(config, items):  # noqa: ARG001
-    if VLLM_INSTALLED:
-        return
-    skip_vllm = pytest.mark.skip(reason="vllm not installed")
-    for item in items:
-        if "vllm" in item.keywords:
-            item.add_marker(skip_vllm)
+def expected_sequence_count(payload):
+    """Sequences the payload should yield: one per choice, or one per output item."""
+    return len(payload.choices) if is_bearable(payload, ChatCompletion) else len(payload.output)

--- a/tests/preprocessing/test_openai_parsing.py
+++ b/tests/preprocessing/test_openai_parsing.py
@@ -1,0 +1,100 @@
+"""Parsing tests for the OpenAI wire formats.
+
+Payloads come from the strategies in `tests/conftest.py`, which build the response models
+directly. Each generated payload is exercised in both representations a caller may hold:
+the model instance (attribute access, as provider SDKs return) and `model_dump()` (the
+plain dict you get from JSON).
+"""
+
+import numpy as np
+import pytest
+from conftest import chat_completions, expected_sequence_count, openai_payloads, responses_api
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from artefactual.preprocessing.parser import LogProbParser, parse_sampled_token_logprobs, parse_top_logprobs
+
+
+@given(payload=chat_completions)
+def test_chat_completion_yields_one_sequence_per_choice(payload):
+    assert len(parse_top_logprobs(payload)) == len(payload.choices)
+
+
+@given(payload=responses_api)
+def test_responses_api_yields_one_sequence_per_output_item(payload):
+    assert len(parse_top_logprobs(payload)) == len(payload.output)
+
+
+@given(payload=openai_payloads)
+def test_dict_and_object_payloads_parse_identically(payload):
+    # the models normalise both representations, so callers can pass either
+    assert parse_top_logprobs(payload.model_dump()) == parse_top_logprobs(payload)
+
+
+@given(payload=openai_payloads)
+def test_logprobs_are_sorted_descending(payload):
+    # the parser promises highest-probability rank first; entropy contributions depend on it
+    for sequence in parse_top_logprobs(payload):
+        for ranks in sequence.values():
+            assert ranks == sorted(ranks, reverse=True)
+
+
+@given(payload=openai_payloads)
+def test_parsed_logprobs_stay_non_positive_and_finite(payload):
+    for sequence in parse_top_logprobs(payload):
+        for ranks in sequence.values():
+            assert all(np.isfinite(value) and value <= 0 for value in ranks)
+
+
+@given(batch=st.lists(openai_payloads, min_size=1, max_size=5))
+def test_batch_is_the_concatenation_of_its_parts(batch):
+    # a calibration dataset is one API call per example; the batch must not lose sequences
+    assert len(parse_top_logprobs(batch)) == sum(expected_sequence_count(p) for p in batch)
+
+
+@given(batch=st.lists(openai_payloads, min_size=2, max_size=4))
+def test_batches_mixing_wire_formats_and_representations_parse(batch):
+    mixed = [p if index % 2 else p.model_dump() for index, p in enumerate(batch)]
+    assert len(parse_top_logprobs(mixed)) == sum(expected_sequence_count(p) for p in batch)
+
+
+@given(batch=st.lists(openai_payloads, min_size=1, max_size=4))
+@settings(deadline=None)
+def test_transform_pads_ragged_batches_to_a_dense_cube(batch):
+    parsed = parse_top_logprobs(batch)
+    array = LogProbParser().transform(batch)
+
+    expected_tokens = max((max(sequence.keys()) + 1 for sequence in parsed if sequence), default=0)
+    expected_ranks = max((len(ranks) for sequence in parsed for ranks in sequence.values()), default=0)
+    assert array.shape == (len(parsed), expected_tokens, expected_ranks)
+
+
+@given(payload=openai_payloads)
+def test_sampled_logprobs_yield_one_array_per_sequence(payload):
+    sampled = parse_sampled_token_logprobs(payload)
+    assert len(sampled) == expected_sequence_count(payload)
+    assert all(array.ndim == 1 for array in sampled)
+
+
+@given(payload=openai_payloads)
+def test_sampled_logprobs_stay_non_positive_and_finite(payload):
+    for array in parse_sampled_token_logprobs(payload):
+        assert np.isfinite(array).all()
+        assert (array <= 0).all()
+
+
+@given(payload=openai_payloads)
+def test_sampled_logprobs_match_across_representations(payload):
+    from_object = parse_sampled_token_logprobs(payload)
+    from_mapping = parse_sampled_token_logprobs(payload.model_dump())
+    assert [a.tolist() for a in from_object] == [a.tolist() for a in from_mapping]
+
+
+def test_empty_batch_returns_no_sequences():
+    assert parse_top_logprobs([]) == []
+    assert LogProbParser().transform([]).shape == (0, 0, 0)
+
+
+def test_unsupported_payload_raises():
+    with pytest.raises(TypeError, match="Unsupported output format"):
+        parse_top_logprobs("not-a-response")

--- a/tests/preprocessing/test_parser.py
+++ b/tests/preprocessing/test_parser.py
@@ -14,66 +14,14 @@ class MockVLLMOutput:
         self.outputs = outputs
 
 
-class MockOpenAIChatCompletion:
-    def __init__(self, choices):
-        self.choices = choices
+# The OpenAI dispatch cases that lived here asserted which processor got called, not what
+# was parsed; they are covered end-to-end in test_openai_parsing.py.
 
 
-class MockOpenAIResponsesAPI:
-    def __init__(self):
-        self.object = "response"
-
-
-@patch("artefactual.preprocessing.parser.process_vllm_top_logprobs")
-def test_parse_top_logprobs_vllm(mock_process):
-    mock_process.return_value = [{0: [-0.1]}]
-    outputs = [MockVLLMOutput(outputs=[1, 2])]
-
-    result = parse_top_logprobs(outputs)
-
-    mock_process.assert_called_once_with(outputs, 2)
-    assert result == [{0: [-0.1]}]
-
-
-def test_parse_top_logprobs_vllm_empty():
-    outputs = [MockVLLMOutput(outputs=[])]
-    result = parse_top_logprobs(outputs)
-    assert result == []
-
-
-@patch("artefactual.preprocessing.parser.process_openai_chat_completion")
-def test_parse_top_logprobs_openai_chat_completion_obj(mock_process):
-    mock_process.return_value = [{0: [-0.2]}]
-    outputs = MockOpenAIChatCompletion(choices=[1, 2, 3])
-
-    result = parse_top_logprobs(outputs)
-
-    mock_process.assert_called_once_with(outputs, iterations=3)
-    assert result == [{0: [-0.2]}]
-
-
-@patch("artefactual.preprocessing.parser.process_openai_chat_completion")
-def test_parse_top_logprobs_openai_chat_completion_dict(mock_process):
-    mock_process.return_value = [{0: [-0.3]}]
-    outputs = {"choices": [1, 2]}
-
-    result = parse_top_logprobs(outputs)
-
-    mock_process.assert_called_once_with(outputs, iterations=2)
-    assert result == [{0: [-0.3]}]
-
-
-@patch("artefactual.preprocessing.parser.is_openai_responses_api")
-@patch("artefactual.preprocessing.parser.process_openai_responses_api")
-def test_parse_top_logprobs_openai_responses_api(mock_process, mock_is_responses):
-    mock_is_responses.return_value = True
-    mock_process.return_value = [{0: [-0.4]}]
-    outputs = MockOpenAIResponsesAPI()
-
-    result = parse_top_logprobs(outputs)
-
-    mock_process.assert_called_once_with(outputs)
-    assert result == [{0: [-0.4]}]
+def test_parse_top_logprobs_no_longer_accepts_vllm_outputs():
+    # standard completion responses only; vLLM outputs must be converted first
+    with pytest.raises(TypeError, match="Unsupported output format"):
+        parse_top_logprobs([MockVLLMOutput(outputs=[])])
 
 
 def test_parse_top_logprobs_unsupported():
@@ -99,30 +47,7 @@ def test_parse_sampled_token_logprobs_vllm_empty():
     assert result == []
 
 
-@patch("artefactual.preprocessing.parser.sampled_tokens_logprobs_chat_completion_api")
-def test_parse_sampled_token_logprobs_openai_chat_completion(mock_process):
-    mock_process.return_value = [np.array([-0.3])]
-    outputs = MockOpenAIChatCompletion(choices=[1])
-
-    result = parse_sampled_token_logprobs(outputs)
-
-    mock_process.assert_called_once_with(outputs)
-    assert len(result) == 1
-    np.testing.assert_array_equal(result[0], np.array([-0.3]))
-
-
-@patch("artefactual.preprocessing.parser.is_openai_responses_api")
-@patch("artefactual.preprocessing.parser.sampled_tokens_logprobs_responses_api")
-def test_parse_sampled_token_logprobs_openai_responses_api(mock_process, mock_is_responses):
-    mock_is_responses.return_value = True
-    mock_process.return_value = [np.array([-0.4])]
-    outputs = MockOpenAIResponsesAPI()
-
-    result = parse_sampled_token_logprobs(outputs)
-
-    mock_process.assert_called_once_with(outputs)
-    assert len(result) == 1
-    np.testing.assert_array_equal(result[0], np.array([-0.4]))
+# The OpenAI sampled-logprob dispatch cases are covered end-to-end in test_openai_parsing.py.
 
 
 def test_parse_sampled_token_logprobs_unsupported():
@@ -189,13 +114,5 @@ def test_sklearn_roundtrip():
 
 
 # Edge cases
-def test_edge_cases():
-    class MockCompletionOutput:
-        logprobs = None
-
-    assert LogProbParser().transform([MockVLLMOutput(outputs=[])]).shape == (0, 0, 0)  # réponse vide
-    assert LogProbParser().transform([MockVLLMOutput(outputs=[MockCompletionOutput()])]).shape == (
-        1,
-        0,
-        0,
-    )  # réponse sans logprobs
+def test_empty_batch_transforms_to_an_empty_cube():
+    assert LogProbParser().transform([]).shape == (0, 0, 0)


### PR DESCRIPTION
## Why

`parse_top_logprobs` could only batch vLLM outputs. OpenAI returns **one response per API call**, so a calibration dataset — a *list* of responses — raised `TypeError`:

```
>>> train_calibration(openai_responses, np.array([0, 1]), "epr")
TypeError: Unsupported output format: list.
```

A single response yields one sequence, so `Pipeline.fit` could never see more than one sample. **Calibration on OpenAI data was impossible.**

It went unnoticed because `test_parser.py` patched the per-format processors and asserted only *dispatch*, so no real payload was ever parsed.

## What changed

**Batching.** A list or tuple of responses is parsed and concatenated; `[]` returns `[]`.

**Validation replaces attribute sniffing.** `hasattr`/`isinstance` dispatch is gone. Two pydantic models (`ChatCompletion`, `ResponsesPayload`) validate through one `TypeAdapter` union, and `functools.singledispatch` routes the result — adding a provider is a registration, not a branch. `from_attributes=True` means a mapping and an SDK object validate into the same model, so the processors see uniform attribute access. Both `parse_top_logprobs` and `parse_sampled_token_logprobs` use this path.

**⚠️ Breaking: `parse_top_logprobs` no longer accepts vLLM outputs.** The library targets standard completion payloads. `process_vllm_top_logprobs` still exists, is still tested, and now emits a `DeprecationWarning`; the vLLM branch of `parse_sampled_token_logprobs` is deprecated in place and still works. Tracked for removal in #304.

**Rank-width alignment restored.** `EPR`/`WEPR` called `entropy_contributions(logprobs_list, self.k)`, but the signature had narrowed to a single `NDArray` — so both raised `BeartypeCallHintParamViolation` on `main`, and the demos were dead. The dropped `k` argument used to truncate or zero-pad the rank axis to the calibrated width; that is reinstated as `align_rank_width`. Zero is the limit of the contribution itself (`-p·log p → 0` as `p → 0`), so absent ranks add nothing.

**Demos run again.** Both replay recorded generation outputs, so they now parse with `process_vllm_top_logprobs` rather than the completion-payload parser.

## Tests

`tests/preprocessing/test_openai_parsing.py` — payloads generated by strategies built **from the response models themselves**, so tests cannot drift from the schema. Both wire formats, both representations (model instance and `model_dump()`), fuzzing ragged rank counts, ragged token counts, multiple choices/output items, batch sizes.

Properties: one sequence per choice/output item · logprobs sorted descending · values finite and `<= 0` · batch == concatenation of its parts · `transform` pads ragged batches to a dense NaN-padded cube · mapping/object parity.

Verified non-vacuous: the batch tests fail against `main` with the `TypeError` above.

Seven mock tests were removed — five asserting *which processor was called* rather than what was parsed, two exercising vLLM routing that no longer exists.

- `pytest`: 92 passed
- `examples/epr_usage_demo.py`: exit 0
- `examples/wepr_demo.ipynb`: executes clean (0.077 confident / 0.781 hallucinating)

## Notes for review

- `align_rank_width` lets WEPR score 5-rank data against 15-rank weights. It restores prior behaviour and unbreaks the demos, but the underlying distribution-shift concern is #296.
- The `TypeError` on validation failure conflates "not a completion response" with "malformed one" — #303.
- `response_models.py` uses `extra="ignore"`; only the logprob path is modelled.

Closes #302. Unblocks #282. Related: #296, #303, #304.
