### PR TITLE
ci: release on a labelled merge, behind a reviewed environment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,25 +1,35 @@
 name: Build
 
+# Called by `pull-request.yaml` to check the package still builds, and by `release.yaml`
+# to produce the distributions it publishes. Building and publishing are separate jobs so
+# a pull request -- which runs code that has not been reviewed yet -- executes in a job
+# holding neither the TestPyPI environment nor `id-token: write`.
 on:
-  push:
-    tags:
-      - 'v[0-9]*'  # Matches v2026.01.0, v2026.01.1, etc.
+  workflow_call:
+    inputs:
+      publish:
+        description: Publish the built distributions to TestPyPI.
+        type: boolean
+        default: false
+      tag:
+        description: >-
+          Tag the distributions must carry. The version is derived from the repository's
+          tags, so naming the expected one here turns a mis-derived version into a failure
+          instead of a wrongly-numbered release.
+        type: string
+        default: ""
 
 permissions:
   contents: read
-  id-token: write  # Required for TestPyPI trusted publishing
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/artefactual
-    env:
-      TAG_NAME: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with:
+          # hatch-vcs reads the version from the most recent reachable tag. A shallow
+          # checkout fetches none and it falls back to 0.1.dev1 with only a warning.
           fetch-depth: 0
           lfs: true
 
@@ -27,41 +37,20 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Get version from code
-        id: version
-        run: |
-          CODE_VERSION=$(uvx bump-my-version show current_version)
-          TAG_VERSION="${TAG_NAME#v}"  # Remove 'v' prefix
-          echo "code_version=$CODE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Validate version matches tag
-        env:
-          CODE_VERSION: ${{ steps.version.outputs.code_version }}
-          TAG_VERSION: ${{ steps.version.outputs.tag_version }}
-        run: |
-          if [ "$CODE_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Version mismatch: code=$CODE_VERSION, tag=$TAG_VERSION"
-            exit 1
-          fi
-          echo "Version validated: $CODE_VERSION"
-
       - name: Build package
         run: uv build
 
       # The wheel is exercised before it is published anywhere, and from an environment
       # built only from its own declared dependencies -- not the project's. A dependency
       # that is needed but unlisted resolves fine in the repo and fails only for a user
-      # installing the wheel, which is precisely what this catches. Publishing to TestPyPI
-      # without this check tests only that an upload succeeds.
+      # installing the wheel, which is precisely what this catches.
       - name: Smoke-test the built wheel
         run: |
           set -euo pipefail
           wheel=$(ls dist/*.whl)
           echo "testing $wheel"
           uv run --isolated --no-project --with "$wheel" python - <<'SMOKE'
-          import artefactual
-          from artefactual.scoring import epr, wepr
+          from artefactual.scoring import epr
 
           # a published detector, resolved and read through the wheel's own dependencies
           detector = epr("chicham/artefactual-epr-ministral", k=15)
@@ -81,6 +70,46 @@ jobs:
           print("wheel imports, resolves a published detector and scores:", float(score[0]))
           SMOKE
 
+      - name: Check the built version against the tag
+        if: inputs.tag != ''
+        env:
+          TAG_NAME: ${{ inputs.tag }}
+        run: |
+          # Compared as versions rather than as strings: PEP 440 normalises the tag's
+          # zero-padded CalVer month, so v2026.08.0 legitimately builds 2026.8.0.
+          uv run --no-project --with packaging python - <<'PY'
+          import os, pathlib, sys
+          from packaging.version import Version
+
+          built = {Version(p.name.split("-")[1]) for p in pathlib.Path("dist").glob("*.whl")}
+          expected = Version(os.environ["TAG_NAME"].removeprefix("v"))
+          if built != {expected}:
+              sys.exit(f"::error::built {sorted(map(str, built))}, expected {expected} from the tag")
+          print(f"built {expected} from {os.environ['TAG_NAME']}")
+          PY
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-testpypi:
+    if: inputs.publish
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/artefactual
+    permissions:
+      id-token: write  # Required for TestPyPI trusted publishing
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
@@ -91,6 +120,9 @@ jobs:
       # it exercises the uploaded metadata and dependency resolution. Dependencies come
       # from real PyPI, since TestPyPI does not mirror them.
       - name: Install from TestPyPI and score
+        if: inputs.tag != ''
+        env:
+          TAG_NAME: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           version="${TAG_NAME#v}"
@@ -100,10 +132,7 @@ jobs:
                  --extra-index-url https://pypi.org/simple/ \
                  --index-strategy unsafe-best-match \
                  --with "artefactual==$version" \
-                 python -c "
-          from artefactual.scoring import epr
-          print('installed from TestPyPI:', epr('chicham/artefactual-epr-ministral', k=15).named_steps['classifier'])
-          "; then
+                 python -c "from artefactual.scoring import epr; print('installed from TestPyPI:', epr('chicham/artefactual-epr-ministral', k=15).named_steps['classifier'])"; then
               exit 0
             fi
             echo "not indexed yet, retrying in 20s (attempt $attempt)"
@@ -111,9 +140,3 @@ jobs:
           done
           echo "::error::artefactual==$version never became installable from TestPyPI"
           exit 1
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,10 +7,6 @@ name: Build
 on:
   workflow_call:
     inputs:
-      publish:
-        description: Publish the built distributions to TestPyPI.
-        type: boolean
-        default: false
       tag:
         description: >-
           Tag the distributions must carry. The version is derived from the repository's
@@ -93,50 +89,3 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-
-  publish-testpypi:
-    if: inputs.publish
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/artefactual
-    permissions:
-      id-token: write  # Required for TestPyPI trusted publishing
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          print-hash: true
-
-      # Installing from TestPyPI rather than from dist/ is the point of publishing there:
-      # it exercises the uploaded metadata and dependency resolution. Dependencies come
-      # from real PyPI, since TestPyPI does not mirror them.
-      - name: Install from TestPyPI and score
-        if: inputs.tag != ''
-        env:
-          TAG_NAME: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          version="${TAG_NAME#v}"
-          for attempt in 1 2 3 4 5; do
-            if uv run --isolated --no-project \
-                 --index https://test.pypi.org/simple/ \
-                 --extra-index-url https://pypi.org/simple/ \
-                 --index-strategy unsafe-best-match \
-                 --with "artefactual==$version" \
-                 python -c "from artefactual.scoring import epr; print('installed from TestPyPI:', epr('chicham/artefactual-epr-ministral', k=15).named_steps['classifier'])"; then
-              exit 0
-            fi
-            echo "not indexed yet, retrying in 20s (attempt $attempt)"
-            sleep 20
-          done
-          echo "::error::artefactual==$version never became installable from TestPyPI"
-          exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Installing the package derives its version from the most recent reachable tag.
+          # A shallow checkout fetches none, and hatch-vcs falls back to 0.1.dev1 with only
+          # a warning, so the site would document a version that was never released.
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@f06b870e0a91d23284a3013acc55e6f88ab4b904  # v7

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,22 @@
+name: Pull request
+
+# Merging to main tags and publishes straight away, so packaging faults have to surface
+# here: after the merge there is no step left at which to catch one without yanking a
+# release. Runs the same build the release uses, with publishing switched off.
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+    with:
+      publish: false

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,5 +18,3 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
-    with:
-      publish: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,11 +65,56 @@ jobs:
       id-token: write  # a called workflow cannot hold more than its caller grants
     uses: ./.github/workflows/build.yaml
     with:
-      publish: true
       tag: ${{ needs.tag.outputs.tag }}
 
-  publish:
+  publish-testpypi:
     needs: [tag, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/artefactual
+    permissions:
+      id-token: write  # Required for TestPyPI trusted publishing
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          print-hash: true
+
+      # Installing from TestPyPI rather than from dist/ is the point of publishing there:
+      # it exercises the uploaded metadata and dependency resolution. Dependencies come
+      # from real PyPI, since TestPyPI does not mirror them.
+      - name: Install from TestPyPI and score
+        if: true
+        env:
+          TAG_NAME: ${{ needs.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${TAG_NAME#v}"
+          for attempt in 1 2 3 4 5; do
+            if uv run --isolated --no-project \
+                 --index https://test.pypi.org/simple/ \
+                 --extra-index-url https://pypi.org/simple/ \
+                 --index-strategy unsafe-best-match \
+                 --with "artefactual==$version" \
+                 python -c "from artefactual.scoring import epr; print('installed from TestPyPI:', epr('chicham/artefactual-epr-ministral', k=15).named_steps['classifier'])"; then
+              exit 0
+            fi
+            echo "not indexed yet, retrying in 20s (attempt $attempt)"
+            sleep 20
+          done
+          echo "::error::artefactual==$version never became installable from TestPyPI"
+          exit 1
+
+  publish:
+    needs: [tag, build, publish-testpypi]
     runs-on: ubuntu-latest
     # Everything outward-facing lives behind this environment, so a required reviewer on
     # it holds the GitHub Release and the PyPI upload together. The tag is already pushed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: Release
 
-# Every merge to main is a release: the tag is created here rather than by hand, and the
-# version is read back off that tag by hatch-vcs, so what is tagged and what is built
-# cannot disagree.
+# A merge to main releases only when its pull request carried the `release` label. The tag
+# is created here rather than by hand, and the version is read back off that tag by
+# hatch-vcs, so what is tagged and what is built cannot disagree.
 #
 # The chain runs inside one workflow. Chaining through `workflow_run` on a pushed tag
 # would never fire: a push made with GITHUB_TOKEN does not start a workflow run, so the
@@ -22,7 +22,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      release: ${{ steps.check.outputs.release }}
+    steps:
+      # A push event carries no labels, so the merged pull request is resolved from the
+      # commit and its labels read back. A commit that belongs to no pull request -- a
+      # direct push to main -- releases nothing, which is the safe default: a version
+      # number is spent permanently and cannot be reissued.
+      - name: Look for the release label on the merged pull request
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          labels=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '[.[].labels[].name] | join(" ")')
+          echo "labels on the merged pull request: ${labels:-<none>}"
+          if printf '%s' "$labels" | tr ' ' '\n' | grep -qx release; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "labelled release: tagging and publishing"
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "not labelled release: nothing is tagged or published"
+          fi
+
   tag:
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create and push the tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,27 +1,92 @@
 name: Release
 
+# Every merge to main is a release: the tag is created here rather than by hand, and the
+# version is read back off that tag by hatch-vcs, so what is tagged and what is built
+# cannot disagree.
+#
+# The chain runs inside one workflow. Chaining through `workflow_run` on a pushed tag
+# would never fire: a push made with GITHUB_TOKEN does not start a workflow run, so the
+# tag would appear and nothing would build.
 on:
-  workflow_run:
-    workflows: [Build]
-    types: [completed]
+  push:
+    branches: [main]
 
 permissions:
-  contents: write
-  id-token: write  # Required for PyPI trusted publishing
+  contents: read
+
+# Serialised, not cancelled: two merges landing together must not both compute "the next
+# tag" from the same base, and abandoning a run part-way through leaves a tag with no
+# release against it.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
 
 jobs:
-  release:
+  tag:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
-    environment:
-      name: pypi
-      url: https://pypi.org/p/artefactual
-    env:
-      TAG_NAME: ${{ github.event.workflow_run.head_branch }}
+    permissions:
+      contents: write  # create and push the tag
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
+          # bump-my-version reads the current version from the most recent reachable tag,
+          # so the tag history is its input, not just the build's.
           fetch-depth: 0
+          lfs: true
+
+      - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b  # v7.2.0
+        with:
+          enable-cache: true
+
+      - name: Compute and create the next tag
+        id: bump
+        run: |
+          # Annotated tags carry a tagger, which a runner has no identity for by default.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Configured to write no files and make no commit, so this only tags HEAD --
+          # which is what keeps the tag an ancestor of main and reachable by `describe`.
+          uvx bump-my-version bump patch
+          tag=$(git describe --tags --exact-match HEAD)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "tagged $tag"
+
+      - name: Push the tag
+        env:
+          TAG_NAME: ${{ steps.bump.outputs.tag }}
+        run: git push origin "$TAG_NAME"
+
+  build:
+    needs: tag
+    permissions:
+      contents: read
+      id-token: write  # a called workflow cannot hold more than its caller grants
+    uses: ./.github/workflows/build.yaml
+    with:
+      publish: true
+      tag: ${{ needs.tag.outputs.tag }}
+
+  publish:
+    needs: [tag, build]
+    runs-on: ubuntu-latest
+    # Everything outward-facing lives behind this environment, so a required reviewer on
+    # it holds the GitHub Release and the PyPI upload together. The tag is already pushed
+    # by then; a tag is cheap to delete, a PyPI version is not reusable.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/artefactual
+    permissions:
+      contents: write  # create the GitHub Release
+      id-token: write  # Required for PyPI trusted publishing
+    env:
+      TAG_NAME: ${{ needs.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag.outputs.tag }}
+          fetch-depth: 0  # git-cliff reads the commits since the previous tag
           lfs: true
 
       - uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b  # v7.2.0
@@ -43,11 +108,6 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Remove pre-existing publish attestations
-        run: rm -f dist/*.publish.attestation
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ _build
 # Quarto / Reveal.js slide output, staged for Sphinx's html_extra_path
 docs/_extra/
 .quarto/
+
+# Build output: the hatch-vcs hook writes the version here from the git tag.
+src/artefactual/_version.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,18 @@ This project uses [CalVer](https://calver.org/) versioning with the format `YYYY
 
 ### Creating a Release
 
-Merging to `main` releases. There is no tag to push and no version to edit: the version
-lives in the git tag, and the tag is created by CI.
+A merge to `main` releases when its pull request carried the **`release`** label, and does
+nothing otherwise. There is no tag to push and no version to edit: the version lives in the
+git tag, and the tag is created by CI.
+
+Label the pull request before merging it:
+
+```bash
+gh pr edit <number> --add-label release
+```
+
+Ordinary merges publish nothing, so a fix to a fix does not spend a version number. A
+commit pushed straight to `main`, belonging to no pull request, never releases.
 
 `bump-my-version` computes the next tag from the most recent reachable one and creates it,
 configured to write no files and make no commit. `hatch-vcs` then reads the version back
@@ -62,6 +72,7 @@ The chain runs in one workflow, because a tag pushed with `GITHUB_TOKEN` does no
 workflow run: chaining on the tag would leave the tag created and nothing built.
 
     merge to main
+      -> gate             is the merged pull request labelled `release`?
       -> tag              bump-my-version creates vYYYY.MM.PATCH
       -> build            hatch-vcs derives the version; the wheel is smoke-tested
       -> publish-testpypi uploaded, then installed back from TestPyPI and scored

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,61 +50,38 @@ This project uses [CalVer](https://calver.org/) versioning with the format `YYYY
 
 ### Creating a Release
 
-Releases are triggered by pushing a version tag.
+Merging to `main` releases. There is no tag to push and no version to edit: the version
+lives in the git tag, and the tag is created by CI.
 
-1. **Bump version (creates commit + tag):**
-    ```bash
-    # For a patch release (e.g., 2026.01.0 -> 2026.01.1)
-    uvx bump-my-version bump patch
+`bump-my-version` computes the next tag from the most recent reachable one and creates it,
+configured to write no files and make no commit. `hatch-vcs` then reads the version back
+off that tag at build time, so what is tagged and what is built cannot disagree — and
+`pyproject.toml` carries no version string to fall out of step.
 
-    # For a new month's release (e.g., 2025.12.5 -> 2026.01.0)
-    uvx bump-my-version bump release
+The chain runs in one workflow, because a tag pushed with `GITHUB_TOKEN` does not start a
+workflow run: chaining on the tag would leave the tag created and nothing built.
 
-    ```
+    merge to main
+      -> tag              bump-my-version creates vYYYY.MM.PATCH
+      -> build            hatch-vcs derives the version; the wheel is smoke-tested
+      -> publish-testpypi uploaded, then installed back from TestPyPI and scored
+      -> publish          GitHub Release + PyPI, held for a required reviewer
 
-    * `patch`: Same month → increment patch (2026.01.0 → 2026.01.1)
-    * `release`: New month → reset patch (2025.12.5 → 2026.01.0)
+The `pypi` environment has a required reviewer, so nothing reaches PyPI unattended. A
+release that should not go out is declined there; the tag is already created by then, and a
+tag is cheap to delete where a PyPI version is not reusable.
 
+Which increment is taken comes from `bump-my-version`'s configuration, following
+[CalVer](https://calver.org/):
 
-2. **Push branch for PR (optional, for testing):**
-    ```bash
-    git push origin your-branch-name
-    gh pr create --title "chore(release): YYYY.MM.PATCH" --body "Version bump"
+* `patch` — same month, increment the patch (2026.01.0 -> 2026.01.1)
+* `release` — a new month, reset the patch (2025.12.5 -> 2026.01.0)
 
-    ```
-
-
-3. **Push the version tag:**
-    ```bash
-    git push origin vYYYY.MM.PATCH
-
-    ```
-
-    The tag push triggers the release workflow which:
-
-    * Validates version in code matches the tag
-    * Generates changelog with git-cliff
-    * Builds the package
-    * Creates GitHub release with artifacts
-    * Triggers PyPI publishing
-
-### Local Changelog Preview
-
-To preview what will be in the next release notes (grouped by the commit types defined above):
+To see what the next tag would be without creating it:
 
 ```bash
-uvx git-cliff --unreleased
-
+uvx bump-my-version show-bump
 ```
 
-### Event-Specific Tags
-
-CalVer tags (e.g., `2026.01.0`) coexist with event-specific tags (e.g., `ECIR2026`). You can create event tags manually:
-
-```bash
-git tag ECIR2026
-git push origin ECIR2026
-
-```
-
-Both tag types can point to the same commit.
+Every pull request runs the same build the release does, with publishing switched off, so a
+packaging fault surfaces before the merge rather than after the tag exists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "artefactual"
-version = "2026.07.0"
+dynamic = ["version"]
 description = "Hallucination detection for black-box LLMs from token log-probabilities"
 readme = "README.md"
 authors = [
@@ -53,8 +53,19 @@ docs = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# The version comes from the most recent tag reachable from HEAD, so a build carries the
+# version of the release it was cut from and no committed file restates it.
+[tool.hatch.version]
+source = "vcs"
+
+# Build output, generated from the tag and never committed, holding the version as a
+# literal for `__init__.py` to import. Written to its own module because the hook
+# overwrites whatever file it targets.
+[tool.hatch.build.hooks.vcs]
+version-file = "src/artefactual/_version.py"
 
 [dependency-groups]
 dev = [
@@ -251,8 +262,11 @@ exclude = ["tests/", "scripts", "examples"]
 [tool.ty.rules]
 unresolved-import = "ignore"
 
+# Computes the next version and creates its tag; it writes no files and makes no commit,
+# because the tag is what the version is read from. `current_version` is absent so the
+# current value is discovered from the most recent tag reachable from HEAD, which keeps
+# the two ends of a release -- what is tagged and what is built -- reading the same source.
 [tool.bumpversion]
-current_version = "2026.07.0"
 parse = """(?x)
     (?P<release>
         (?:[1-9][0-9]{3})\\.     # YYYY.
@@ -261,7 +275,7 @@ parse = """(?x)
     \\.(?P<patch>\\d+)           # .patch
 """
 serialize = ["{release}.{patch}"]
-commit = true
+commit = false
 tag = true
 tag_name = "v{new_version}"
 
@@ -270,13 +284,3 @@ calver_format = "{YYYY}.{0M}"
 
 [tool.bumpversion.parts.patch]
 first_value = "0"
-
-[[tool.bumpversion.files]]
-filename = "pyproject.toml"
-search = 'version = "{current_version}"'
-replace = 'version = "{new_version}"'
-
-[[tool.bumpversion.files]]
-filename = "src/artefactual/__init__.py"
-search = '__version__ = "{current_version}"'
-replace = '__version__ = "{new_version}"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,11 +61,37 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+# Without this the default scheme guesses the *next* version by incrementing the last
+# component -- 2026.07.0 becomes 2026.7.1.devN. Under CalVer the next release is
+# 2026.08.0, so that guess names a version that will never exist. `no-guess-dev` counts
+# forward from the released tag instead: 2026.7.0.post1.devN.
+raw-options = { version_scheme = "no-guess-dev" }
+
 # Build output, generated from the tag and never committed, holding the version as a
 # literal for `__init__.py` to import. Written to its own module because the hook
 # overwrites whatever file it targets.
 [tool.hatch.build.hooks.vcs]
 version-file = "src/artefactual/_version.py"
+
+# hatch-vcs offers hatchling every path the VCS knows about, and with no explicit target
+# the sdist takes the repository root -- .jj, .workspaces and the docs build included,
+# which is 22 MB of working state a user never asked for. Both targets are named here so
+# what ships is what the package needs to build and be tested.
+[tool.hatch.build.targets.sdist]
+# Anchored with a leading slash: unanchored, `src/artefactual` also matches
+# `.workspaces/<name>/src/artefactual`, and a jj workspace checked out under the repo
+# would be packaged along with it.
+include = [
+    "/src/artefactual",
+    "/tests",
+    "/pyproject.toml",
+    "/README.md",
+    "/LICENSE",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/artefactual"]
+
 
 [dependency-groups]
 dev = [

--- a/src/artefactual/__init__.py
+++ b/src/artefactual/__init__.py
@@ -1,3 +1,5 @@
 """Artefactual: hallucination detection for black-box LLMs, as scikit-learn estimators."""
 
-__version__ = "2026.07.0"
+from artefactual._version import __version__
+
+__all__ = ["__version__"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -47,8 +47,35 @@ def test_the_notebook_parses(name):
     compile(code_of(load(name)), name, "exec")
 
 
+@pytest.fixture
+def _detectors_resolve_locally(monkeypatch, tmp_path):
+    """Resolve a published detector name to an estimator written here, not fetched.
+
+    The notebooks name a Hugging Face repository, which is what a reader should copy, so
+    running them as written reaches the network -- and a runner blip then fails a build
+    that has nothing to do with the Hub. Only the resolution step is replaced: the
+    notebook's own code, `read_estimator`, and the whole pipeline still run for real.
+
+    The width follows the reduction the name carries, because that is what the classifier
+    is checked against: EPR pools to a single coefficient, WEPR keeps `2k`.
+    """
+    import skops.io as sio
+    from conftest import fitted_logistic
+
+    from artefactual.scoring.base_detector import BaseDetector
+
+    def resolve(identifier, *_args, **_kwargs):
+        n_features = 1 if "-epr-" in str(identifier) else 2 * 15
+        path = tmp_path / f"{n_features}.skops"
+        if not path.exists():
+            sio.dump(fitted_logistic(-0.5, [0.1] * n_features), path)
+        return path
+
+    monkeypatch.setattr(BaseDetector, "resolve_estimator", staticmethod(resolve))
+
+
 @pytest.mark.parametrize("name", OFFLINE_NOTEBOOKS)
-def test_the_notebook_runs_against_the_current_source(name, monkeypatch):
+def test_the_notebook_runs_against_the_current_source(name, monkeypatch, _detectors_resolve_locally):
     """Execute every code cell in order, from the notebook's own directory.
 
     Run in-process rather than through nbconvert: the failure surfaces as an ordinary


### PR DESCRIPTION
Closes #262

Releases become opt-in: a merge to `main` publishes only when its pull request carried the `release` label. `bump-my-version` creates the tag, `hatch-vcs` reads the version back off it, and the GitHub Release and PyPI upload sit behind the `pypi` environment's required reviewer.

Packaging fixes the release path exposed are included, because a first release would otherwise ship them: the sdist was 22 MB of `.jj` and `.workspaces` (now 52 KB), dev builds advertised a `2026.7.1` that CalVer will never produce, and the notebook tests reached the Hub on every run.