### PR TITLE
docs(ecir): draw the question pack from a QA dataset, and fix stale claims

### DIFF
--- a/scripts/ecir/README.md
+++ b/scripts/ecir/README.md
@@ -15,15 +15,15 @@ model.
 | | Why | Where |
 |---|---|---|
 | `vllm` | Runs the two LLM stages | A Linux GPU box — it has no macOS wheels. Run via `uvx`, no install; the wheel must match the driver's CUDA — see [running `vllm`](#running-vllm) |
-| `jq` | Builds the batch request files | Anywhere |
+| `jq` | Every script here shapes JSON with it | Anywhere |
+| `datasets` | Only if step 1 draws from the Hub rather than a hand-written file | Anywhere; `build_questions.sh` fetches it into an ephemeral environment, so no install and no built checkout is needed |
 | This repo, `uv sync`'d | Trains and evaluates the detector | Anywhere |
-| `questions.json` | Your QA pack — see below | You write this |
 
 The work falls into three phases, and only the middle one needs a GPU:
 
 | Phase | What happens | GPU | Cost |
 |---|---|---|---|
-| **A. Prepare the data** | Write the questions, render them as batch requests | no | minutes |
+| **A. Prepare the data** | Draw the questions, render them as batch requests | no | minutes |
 | **B. Run the models** | Generate answers, then grade them — two `vllm run-batch` passes | **yes** | hours |
 | **C. Train and evaluate** | Fit the detector on the labels, score it on held-out data | no | seconds |
 
@@ -38,7 +38,7 @@ The detector is a logistic regression trained on `(response, was_it_a_hallucinat
 You supply the questions and their gold answers; the pipeline produces the responses, and
 the LLM judge produces the labels.
 
-The only file authored by hand is `questions.json`, a list of:
+Steps 2 and 4 read one file, `questions.json`, a list of:
 
 ```json
 [{"question": "Who sent Augustine to England?",
@@ -54,9 +54,12 @@ The only file authored by hand is `questions.json`, a list of:
 | `short_answer` | yes | The gold answer the judge grades against |
 | `answer_aliases` | no | Other answers the judge should accept; omit or leave empty |
 
-The paper uses **TriviaQA** for training and **WebQuestions** to test generalisation, plus
-a financial RAG corpus (ArGiMi-Ardian) for missing-context detection. Any short-form QA set
-works, including domain-specific question sets. Two properties matter:
+Step 1 writes it either from a Hugging Face QA dataset or by hand. The paper trains on **TriviaQA**, which ships each gold answer with the
+aliases the judge should also accept; it tests generalisation on **WebQuestions**, and uses
+a financial RAG corpus (ArGiMi-Ardian) for missing-context detection.
+
+Any short-form QA set works either way, including a domain-specific one that exists only as
+your own file. Two properties matter:
 
 - **Answers must be short enough to grade automatically.** The judge compares against
   `short_answer`; an essay cannot be scored this way.
@@ -87,10 +90,43 @@ mkdir -p "$OUT"
 
 No GPU. Everything here is cheap and worth getting right before spending GPU hours.
 
-### Step 1 — write `questions.json`
+### Step 1 — build `questions.json`
 
-The only hand-authored file. See [the training data](#the-training-data) above for the
-schema and for the properties of a usable question set.
+Steps 2 and 4 read this file, in the schema [above](#the-training-data); after that
+`question_id` travels on as `custom_id` and the later stages join on that.
+
+```bash
+./build_questions.sh triviaqa 500 > questions.json
+```
+
+The paper trains on **TriviaQA**, whose closed-book configuration carries every field the
+pack needs, including the aliases the judge should also accept. 500 rows yield 493
+questions at the default seed: the split concatenates two evidence sources, so some
+questions appear twice
+under one id and the script keeps one of each. `./build_questions.sh --help` explains that
+and the alias handling.
+
+```bash
+./build_questions.sh webquestions > questions.json
+```
+
+**WebQuestions** is the paper's generalisation set. Its test split is 2,032 questions,
+small enough to take whole, so it has no sample size.
+
+Or write the file by hand, which is the right choice for a domain-specific question set
+where no public dataset applies. Three fields are the whole requirement; `answer_aliases`
+is optional, and [the schema](#the-training-data) says what it buys:
+
+```json
+[{"question": "Who sent Augustine to England?",
+  "question_id": "q-1",
+  "short_answer": "Pope Gregory"}]
+```
+
+`question_id` becomes `custom_id` and every later stage joins on it, so a duplicate would
+pair a generation with another question's verdict. Nothing here checks for that, because
+step 2 does: `build_generation_requests.sh` refuses a pack whose ids repeat, names them,
+and reports the question count it is building for.
 
 ### Step 2 — build the generation requests
 
@@ -99,12 +135,8 @@ schema and for the properties of a usable question set.
 ```
 
 One JSON line per question, in the OpenAI batch format, asking for `top_logprobs: $K`.
-Check it before spending GPU time:
-
-```bash
-head -1 "$OUT/gen_requests.jsonl" | jq '{custom_id, model: .body.model, k: .body.top_logprobs}'
-wc -l < "$OUT/gen_requests.jsonl"   # should equal the question count
-```
+The script reports on stderr how many requests it built, for which model and at which `k`
+— read that line before spending GPU time, because `K` here and `--k` in step 6 must agree.
 
 Sampling follows the paper (§4.1.2): non-greedy decoding at `T_samp = 1.0`, `top_p = 1.0`,
 sampling cutoff `K_samp = 50`. Override with `GEN_TEMPERATURE`, `GEN_TOP_P`, `GEN_TOP_K`.
@@ -173,15 +205,15 @@ by hand, and cap the context if the model's default exceeds what one card holds
 vllm run-batch -i "$OUT/gen_requests.jsonl" -o "$OUT/responses.jsonl" --model "$MODEL"
 ```
 
-Confirm every request came back with the right rank width:
+Confirm the batch before spending the judge's GPU hours on it:
 
 ```bash
-jq -r 'select(.response != null)
-       | (.response.body // .response).choices[0].logprobs.content[0].top_logprobs | length' "$OUT/responses.jsonl" | sort -u
+./check_responses.sh "$OUT/responses.jsonl"
 ```
 
-One number should print, and it must equal `$K`. If it is smaller, the generation ignored
-`top_logprobs` — fix that and rerun, because step 6 will refuse the data.
+It reports how many lines carry a completion, names every line that does not with its
+status, and prints the rank widths present. One width should print, and it must equal `$K`
+— if it is smaller the generation ignored `top_logprobs`, and step 6 will refuse the data.
 
 ### Step 4 — build the judge requests
 
@@ -203,10 +235,10 @@ answer was **correct**, so the training label is its negation — 1 marks a hall
 Spot-check a few, then check the class balance:
 
 ```bash
-jq -r 'select(.response != null) | (.response.body // .response).choices[0].message.content' "$OUT/judgments.jsonl" | head -3
+./check_responses.sh "$OUT/judgments.jsonl"
 
-jq -r 'select(.response != null) | (.response.body // .response).choices[0].message.content' "$OUT/judgments.jsonl" \
-  | grep -c '"judgment": *true'
+./verdicts.sh "$OUT/judgments.jsonl" | head -3
+./verdicts.sh "$OUT/judgments.jsonl" | grep -c '"judgment": *true'
 ```
 
 Compare that count against the question count. All-correct or all-wrong cannot be fit;
@@ -239,8 +271,8 @@ refitted and discarded.
 chance of picking up a different install. Numbers here are illustrative:
 
 ```
-joined 400 pairs on custom_id (112 hallucinations)
-fitting on 300 response(s), holding out 100
+joined 495 pairs on custom_id (139 hallucinations)
+fitting on 371 response(s), holding out 124
 intercept: -3.02
 wrote out/wepr.skops
 
@@ -351,8 +383,9 @@ Supplying WEPR weights whose rank count disagrees with `--k` is caught separatel
 coefficient vector:
 
 ```
-ValueError: Weights cover 15 rank(s) but k=20 was requested. WEPR coefficients are fixed
-at the rank count they were trained at; pass k=15, or supply weights trained at k=20.
+ValueError: The wepr detector at 'out/wepr.skops' takes 30 feature(s), but k=20 needs 40.
+Its coefficients are fixed at the rank count they were trained at; pass k=15, or use a
+detector trained at k=20.
 ```
 
 Responses generated at a narrower `k` must be regenerated; a detector trained at another
@@ -364,11 +397,10 @@ was produced with a smaller `top_logprobs` than the fitted `k`, most often becau
 and step 6 were run with different values. The responses can be inspected directly:
 
 ```bash
-jq -r 'select(.response != null)
-       | (.response.body // .response).choices[0].logprobs.content[0].top_logprobs | length' out/responses.jsonl | sort -u
+./check_responses.sh out/responses.jsonl
 ```
 
-One number should come back, and it must be at least `--k`. If it is smaller, rerun
+One width should come back, and it must be at least `--k`. If it is smaller, rerun
 steps 2 and 3 — the judgments are unaffected and do not need regenerating.
 
 **`joined N pairs on custom_id` reports fewer than the question count.** Some requests
@@ -379,21 +411,19 @@ comes back with `error` null, a non-2xx `status_code`, and an error object sitti
 the completion would be.
 
 ```bash
-jq -c 'select(.error != null or .response == null
-              or .response.status_code < 200 or .response.status_code >= 300
-              or .response.body == null)
-       | {custom_id, status: .response.status_code, error}' out/responses.jsonl
+./check_responses.sh out/responses.jsonl
 ```
 
-An envelope with no `status_code` is refused by the script rather than assumed to have
-succeeded, so this triage never reports fewer failures than the run dropped.
+It applies the same rule `build_judge_requests.sh` does, so it never reports fewer failures
+than the run dropped — including an envelope with no `status_code`, which is refused rather
+than assumed to have succeeded.
 
 **`dropped N verdict(s) that could not be parsed`.** The judge is asked for
 `{"judgment": true|false, "explanation": "..."}` and returned something else. Inspect a
 few and, if the model is simply chatty, raise `JUDGE_MAX_TOKENS`:
 
 ```bash
-jq -r 'select(.response != null) | (.response.body // .response).choices[0].message.content' out/judgments.jsonl | head
+./verdicts.sh out/judgments.jsonl | head
 ```
 
 **`No custom_id is present in both files`.** The two files came from different batches.
@@ -401,11 +431,23 @@ jq -r 'select(.response != null) | (.response.body // .response).choices[0].mess
 joins by id — a reordered or partially failed batch can never pair a generation with the
 wrong verdict, but two unrelated batches will not join at all.
 
-**`5-fold cross-validation needs at least 5 of each class` from the evaluation.** The rarer
-class — usually the hallucinations — has fewer members than there are folds, so it cannot
-appear in every one. The message prints the actual counts. Label more data, or lower
-`--folds`; note that fewer folds means a noisier estimate, so treat it as a way to get a
-reading at all rather than a fix.
+**`Both classes are needed to fit a detector`, or `A stratified holdout needs at least 2 of
+each class`.** The labelled set has only one class, or too few of the rarer one to put one
+on each side of the split. Both messages print the actual counts:
+
+```
+ValueError: A stratified holdout needs at least 2 of each class, but the labels are
+{0: 499, 1: 1} (0 = grounded, 1 = hallucination). Label more data, or pass --test_size 0
+to fit without evaluating.
+```
+
+Label more data, or change step 1's questions -- harder if nothing was hallucinated,
+easier if everything was.
+
+`--test_size 0` answers only the second message. It skips the split, so it fits on
+everything and gets a file written, telling you nothing about it. It is no help against the
+first: with one class there is nothing to fit, and skipping the split only moves the error
+into scikit-learn, which raises `This solver needs samples of at least 2 classes`.
 
 ## What the scripts read
 
@@ -423,6 +465,19 @@ its `body`. Steps 3, 6 and 7 unwrap it themselves, so there is no conversion ste
 envelope when inspecting a file by hand: `jq '.response.choices[0]'` silently yields `null`
 rather than failing.
 
+Five scripts, each taking positional arguments and writing to stdout:
+
+| Script | Reads | Writes |
+|---|---|---|
+| `build_questions.sh` | a Hugging Face QA dataset | `questions.json` in the schema above |
+| `build_generation_requests.sh` | `questions.json` | batch requests; refuses repeated ids |
+| `build_judge_requests.sh` | `questions.json`, the generations | batch requests; drops failed lines and says how many |
+| `check_responses.sh` | any batch output | usable count, the dropped ids with their status, the rank widths present |
+| `verdicts.sh` | the judgments | the judge's reply from each line that carries one |
+
+The last two only read, so they are safe to run against a batch at any point. The three
+that read a batch decide what a line carries the same way: `error` null, a 2xx `status_code`, and a body.
+
 ## Prompts
 
 `prompts/generate.txt` and `prompts/judge.txt` hold the paper's prompts verbatim.
@@ -430,8 +485,10 @@ Placeholders are substituted by `jq` with literal split/join, so a question cont
 backslashes, `&` or quotes cannot corrupt the rendering.
 
 `prompts/judge.jinja` is the original jinja2 template, kept so the rendering can be
-re-checked against it — it was verified byte-identical for 0, 1 and 2 aliases. Edit the
-prompts and the run no longer reproduces the paper.
+re-checked against it — it is verified byte-identical for 0, 1, 2 and 40 aliases, the
+last because TriviaQA questions carry a median of 8 and a long tail: measured over a
+500-row sample, the mean is 13 and the widest question has 158. Edit the prompts and the
+run no longer reproduces the paper.
 
 The judge's `judgment: true` means the answer was correct, so the training label is its
 negation: **1 marks a hallucination**.

--- a/scripts/ecir/build_generation_requests.sh
+++ b/scripts/ecir/build_generation_requests.sh
@@ -18,7 +18,9 @@
 #                    one, it only notes the tasks yield short answers)
 #
 # `question_id` becomes `custom_id`, which run-batch carries into its output so every
-# later stage joins by id rather than by line order.
+# later stage joins by id rather than by line order. A pack whose ids repeat is refused
+# here rather than at the join, where the symptom is a generation paired with another
+# question's verdict and nothing says so.
 #
 # `k` must match the `--k` passed when fitting: EPR averages over exactly k ranks, so the
 # rank count is part of the feature definition, and the fit refuses narrower responses.
@@ -43,6 +45,16 @@ top_k=${GEN_TOP_K:-50}
 max_tokens=${GEN_MAX_TOKENS:-200}
 
 [ -f "$questions" ] || { echo "error: no such question pack: $questions" >&2; exit 1; }
+
+total=$(jq 'length' "$questions")
+distinct=$(jq '[.[].question_id] | unique | length' "$questions")
+if [ "$distinct" -ne "$total" ]; then
+  echo "error: $questions has $total question(s) under $distinct id(s); ids must be unique" >&2
+  jq -r '[.[].question_id] | group_by(.) | map(select(length > 1)) | .[] | "  repeated: \(.[0])"' \
+    "$questions" >&2
+  exit 1
+fi
+echo "building $total request(s) for $model at k=$k" >&2
 
 jq -c \
   --rawfile tpl "$here/prompts/generate.txt" \

--- a/scripts/ecir/build_judge_requests.sh
+++ b/scripts/ecir/build_judge_requests.sh
@@ -22,7 +22,7 @@
 # Lines are read as the OpenAI Batch output spec defines them -- no other shape is accepted.
 #
 # The prompt is rendered by literal split/join rather than regex substitution, so a
-# question containing backslashes or `&` cannot corrupt it. `tests/test_ecir_prompts.py`
+# question containing backslashes or `&` cannot corrupt it. `tests/test_ecir_pipeline.py`
 # checks the result byte-for-byte against the original Jinja template.
 set -euo pipefail
 

--- a/scripts/ecir/build_questions.sh
+++ b/scripts/ecir/build_questions.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Build a question pack from a Hugging Face QA dataset.
+#
+# Usage:
+#   build_questions.sh <triviaqa|webquestions> [n] > questions.json
+#
+# Arguments:
+#   dataset  triviaqa     the paper's training set, sampled
+#            webquestions the paper's generalisation set, taken whole
+#   n        questions to sample, triviaqa only (default 500)
+#
+# Environment:
+#   QUESTIONS_SEED  shuffle seed for the triviaqa sample (default 42)
+#
+# Writes the schema steps 2 and 4 read: a JSON list of
+# {question, question_id, short_answer, answer_aliases}. A pack can equally be written by
+# hand in that schema -- the rest of the pipeline cannot tell the two apart.
+#
+# `uv` fetches `datasets` into an ephemeral environment. `--no-project` keeps that
+# independent of the checkout it runs from: building the repo is not needed to shape a
+# question pack, and an export without version metadata cannot be built at all. Rows land
+# in a temporary file and are deleted on exit.
+set -euo pipefail
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "${BASH_SOURCE[0]}"
+  exit 0
+fi
+
+dataset=${1:?usage: build_questions.sh triviaqa|webquestions [n]}
+n=${2:-500}
+seed=${QUESTIONS_SEED:-42}
+
+rows=$(mktemp)
+trap 'rm -f "$rows"' EXIT
+
+# TriviaQA's closed-book configuration carries every field the pack needs. The split
+# arrives grouped by source, so shuffling before sampling is what makes `n` rows a sample
+# of the set rather than of its first source.
+read -r -d '' fetch_triviaqa <<'PY' || true
+import sys
+from datasets import load_dataset
+split = load_dataset("mandarjoshi/trivia_qa", "rc.nocontext", split="validation")
+split.shuffle(seed=int(sys.argv[1])).select(range(int(sys.argv[2]))).to_json(sys.argv[3])
+PY
+
+# `rc.nocontext` is `rc.web.nocontext` and `rc.wikipedia.nocontext` concatenated (9,951 +
+# 7,993 = 17,944 validation rows, over at most 11,313 distinct questions), so a question
+# with both kinds of evidence appears twice under the same id. What told the two rows apart
+# is the evidence, which is exactly what `.nocontext` drops, so the fields read here are the
+# question's own annotation either way -- and keeping both would pay for the same
+# generation twice. Expect a little under `n` questions out of `n` rows.
+#
+# TriviaQA questions carry a median of 8 aliases and a long tail -- mean 13, and 158 at the
+# widest, measured over a 500-row sample -- every one of them rendered into the judge
+# prompt. `unique_by(ascii_downcase)` collapses the ones that differ only in case; the
+# `select` drops the ones that restate the gold answer, which the prompt already carries on
+# its own line.
+read -r -d '' shape_triviaqa <<'JQ' || true
+[ .[]
+  # Bound here because inside the `select` below `.` is the alias, not the row.
+  | .answer.value as $gold
+  | {question,
+     question_id,
+     short_answer: $gold,
+     answer_aliases: ([.answer.aliases[] | select(ascii_downcase != ($gold | ascii_downcase))]
+                      | unique_by(ascii_downcase))} ]
+| unique_by(.question_id)
+JQ
+
+# WebQuestions has no config and no id column, and carries one flat answer list that serves
+# both answer fields. Its test split is 2,032 questions, small enough to take whole -- which
+# is also what makes the row position a usable id, since it is the same number on every run.
+# Sample first and the id would mean a position in that sample, so a new seed or size
+# rebinds it and a stale responses.jsonl would join old generations to new questions with
+# nothing to report it. The `wq-` prefix keeps these out of a hand-written `q-1` namespace.
+read -r -d '' fetch_webquestions <<'PY' || true
+import sys
+from datasets import load_dataset
+load_dataset("stanfordnlp/web_questions", split="test").to_json(sys.argv[3])
+PY
+
+# jq has no error for reading a field that is not there: `.answers[0]` on an empty list is
+# null, and a null gold answer reaches the judge as an empty string, which grades every
+# answer against nothing. Dropped here instead. The split has no such row today; the guard
+# is against pointing this at a set that does.
+read -r -d '' shape_webquestions <<'JQ' || true
+[ to_entries[]
+  | select((.value.answers | length) > 0)
+  | .value.answers[0] as $gold
+  | {question: .value.question,
+     question_id: "wq-\(.key)",
+     short_answer: $gold,
+     answer_aliases: ([.value.answers[1:][] | select(ascii_downcase != ($gold | ascii_downcase))]
+                      | unique_by(ascii_downcase))} ]
+JQ
+
+case "$dataset" in
+  triviaqa)     fetch=$fetch_triviaqa;     shape=$shape_triviaqa ;;
+  webquestions) fetch=$fetch_webquestions; shape=$shape_webquestions ;;
+  *) echo "error: unknown dataset: $dataset (expected triviaqa or webquestions)" >&2; exit 1 ;;
+esac
+
+uv run --no-project --with datasets python -c "$fetch" "$seed" "$n" "$rows" >&2
+jq -s "$shape" "$rows"

--- a/scripts/ecir/check_responses.sh
+++ b/scripts/ecir/check_responses.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Report what a `vllm run-batch` output file actually contains.
+#
+# Usage:
+#   check_responses.sh <batch_output.jsonl>
+#
+# Prints, in order: how many lines carry a usable completion, the custom_id and status of
+# every line that does not, and the distinct rank widths present. Exits non-zero when
+# nothing is usable.
+#
+# The rank width is the number this is worth running for. `top_logprobs` is a request the
+# server may ignore, and a batch generated at a narrower width than the fit expects is only
+# discovered by step 6 -- two GPU stages later.
+set -euo pipefail
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "${BASH_SOURCE[0]}"
+  exit 0
+fi
+
+responses=${1:?usage: check_responses.sh batch_output.jsonl}
+[ -f "$responses" ] || { echo "error: no such file: $responses" >&2; exit 1; }
+
+# The same rule build_judge_requests.sh applies. The Batch spec reports failure two ways --
+# top-level `error` for non-HTTP failures, and `error` null with a non-2xx `status_code` and
+# an error object where the completion would be -- so a body is not evidence of a completion.
+read -r -d '' usable <<'JQ' || true
+def usable:
+  if .error != null or .response == null then false
+  else
+    (.response.status_code
+     // error("custom_id \(.custom_id): response envelope carries no status_code")) as $status
+    | $status >= 200 and $status < 300 and .response.body != null
+  end;
+JQ
+
+total=$(wc -l <"$responses" | tr -d " ")
+kept=$(jq -s "$usable"' map(select(usable)) | length' "$responses")
+echo "$kept/$total line(s) carry a completion"
+
+if [ "$kept" -ne "$total" ]; then
+  jq -r "$usable"' select(usable | not)
+    | "  dropped \(.custom_id): status=\(.response.status_code // "none") error=\(.error // "none")"' \
+    "$responses"
+fi
+
+[ "$kept" -gt 0 ] || { echo "error: no line carries a completion" >&2; exit 1; }
+
+# Only the generation batch asks for logprobs; a judge batch has none, and reporting a
+# width of 0 for it would read as a batch generated at the wrong k. One width should print.
+# More than one means the batch was not generated in a single pass.
+widths=$(jq -r "$usable"' select(usable and .response.body.choices[0].logprobs != null)
+  | .response.body.choices[0].logprobs.content[0].top_logprobs | length' "$responses" | sort -u)
+if [ -n "$widths" ]; then
+  echo "rank width(s) present:"
+  echo "$widths" | sed "s/^/  /"
+else
+  echo "no logprobs in this batch (expected for judgments)"
+fi

--- a/scripts/ecir/verdicts.sh
+++ b/scripts/ecir/verdicts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Print the judge's reply from every line of a batch output file that carries one.
+#
+# Usage:
+#   verdicts.sh <judgments.jsonl>
+#
+# One reply per line, in file order, as the judge wrote it -- `{"judgment": ..., ...}` when
+# it followed the prompt, whatever it said instead when it did not. Lines that failed are
+# skipped silently; `check_responses.sh` is what accounts for those.
+#
+# Piping this to `grep -c '"judgment": *true'` gives the class balance, which is the number
+# step 1 is tuned against: a pack nothing hallucinates on cannot be fit.
+set -euo pipefail
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "${BASH_SOURCE[0]}"
+  exit 0
+fi
+
+judgments=${1:?usage: verdicts.sh judgments.jsonl}
+[ -f "$judgments" ] || { echo "error: no such file: $judgments" >&2; exit 1; }
+
+# A body is not evidence of a completion: a rejected request carries an error object where
+# the completion would be. The same rule build_judge_requests.sh and check_responses.sh
+# apply, including refusing an envelope with no status_code rather than reading it as a
+# success.
+read -r -d '' usable <<'JQ' || true
+def usable:
+  if .error != null or .response == null then false
+  else
+    (.response.status_code
+     // error("custom_id \(.custom_id): response envelope carries no status_code")) as $status
+    | $status >= 200 and $status < 300 and .response.body != null
+  end;
+JQ
+
+jq -r "$usable"' select(usable) | .response.body.choices[0].message.content' "$judgments"

--- a/tests/test_ecir_pipeline.py
+++ b/tests/test_ecir_pipeline.py
@@ -33,6 +33,15 @@ QUESTIONS = [
     # backslash, ampersand and quotes: a regex-based renderer would corrupt these
     {"question": 'Capital? A\\B & C "quoted"', "question_id": "q-2", "short_answer": "Paris", "answer_aliases": []},
     {"question": "One alias?", "question_id": "q-3", "short_answer": "X", "answer_aliases": ["Y"]},
+    # Step 1 draws from TriviaQA, whose questions carry a median of 8 aliases and a long
+    # tail -- 158 at the widest, measured over a 500-row sample. The rendering was only ever
+    # held to 0, 1 and 2, which is no longer the shape it runs on.
+    {
+        "question": "Many aliases?",
+        "question_id": "q-4",
+        "short_answer": "Ada Lovelace",
+        "answer_aliases": [f"alias {i}" for i in range(40)],
+    },
 ]
 
 
@@ -170,6 +179,71 @@ def test_a_rejected_generation_is_dropped_even_though_error_is_null(pack):
     rows = [json.loads(line) for line in result.stdout.splitlines()]
     assert [row["custom_id"] for row in rows] == [q["question_id"] for q in QUESTIONS]
     assert "dropping 1/" in result.stderr
+
+
+# --- the scripts that guard a run ------------------------------------------------------
+
+
+def test_a_pack_whose_ids_repeat_is_refused_before_any_gpu_time(pack):
+    """`custom_id` is the only join key, so a repeat would pair a generation with the
+    wrong verdict. The script names the offending id rather than failing at the join."""
+    path = pack / "duplicated.json"
+    repeated = [*QUESTIONS, {**QUESTIONS[0], "question": "asked twice under one id"}]
+    path.write_text(json.dumps(repeated), encoding="utf-8")
+
+    result = subprocess.run(
+        [str(ECIR / "build_generation_requests.sh"), str(path), "m", "15"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert QUESTIONS[0]["question_id"] in result.stderr
+    assert result.stdout == ""
+
+
+def test_the_triage_names_a_rejected_line_and_reports_the_rank_width(pack):
+    path = pack / "with_rejection.jsonl"
+    path.write_text(json.dumps(rejected_line("q-9")) + "\n" + (pack / "responses.jsonl").read_text(), encoding="utf-8")
+
+    out = run(ECIR / "check_responses.sh", path)
+
+    assert f"{len(QUESTIONS)}/{len(QUESTIONS) + 1} line(s) carry a completion" in out
+    assert "dropped q-9: status=400" in out
+    # batch_line builds three ranks per token, and every usable line agrees on that
+    assert "rank width(s) present:\n  3\n" in out
+
+
+def test_the_triage_says_so_rather_than_reporting_a_width_of_zero_for_judgments(pack):
+    """A judge batch asks for no logprobs; a width of 0 would read as a bad generation."""
+    line = batch_line("q-1", '{"judgment": true}')
+    del line["response"]["body"]["choices"][0]["logprobs"]
+    path = pack / "judgments.jsonl"
+    path.write_text(json.dumps(line) + "\n", encoding="utf-8")
+
+    out = run(ECIR / "check_responses.sh", path)
+
+    assert "no logprobs in this batch" in out
+    assert "rank width" not in out
+
+
+def test_the_triage_fails_when_no_line_carries_a_completion(pack):
+    path = pack / "all_rejected.jsonl"
+    path.write_text("\n".join(json.dumps(rejected_line(q["question_id"])) for q in QUESTIONS) + "\n", encoding="utf-8")
+
+    result = subprocess.run([str(ECIR / "check_responses.sh"), str(path)], capture_output=True, text=True, check=False)
+
+    assert result.returncode != 0
+    assert "no line carries a completion" in result.stderr
+
+
+def test_verdicts_prints_only_the_lines_that_carry_a_reply(pack):
+    path = pack / "judgments.jsonl"
+    kept = batch_line("q-1", '{"judgment": true, "explanation": "ok"}')
+    path.write_text(json.dumps(kept) + "\n" + json.dumps(rejected_line("q-9")) + "\n", encoding="utf-8")
+
+    assert run(ECIR / "verdicts.sh", path).splitlines() == ['{"judgment": true, "explanation": "ok"}']
 
 
 def test_an_envelope_with_no_status_code_stops_the_run_and_names_the_line(pack):


### PR DESCRIPTION
Step 1 said "write `questions.json`" and left the reader to author several hundred question/answer pairs by hand before anything else could run. The paper trains on TriviaQA, which is on the Hub and carries every field the pack needs, so step 1 now shows both routes: `datasets` dumps the split in one call, `jq` renames the fields as it does for every other file in this pipeline, and hand-writing stays documented for a domain-specific set no public dataset covers. `questions.json` is still the only interface, and the rest of the pipeline cannot tell the two apart.

## The one that would have cost GPU hours

The `jq` deduplicates by `question_id`, and that is not defensive tidiness. `rc.nocontext` is `rc.web.nocontext` and `rc.wikipedia.nocontext` **concatenated**:

```
9,951 + 7,993 = 17,944 validation rows,  against at most 11,313 distinct questions
```

So a question with both kinds of evidence arrives twice under one id — and the evidence columns that told the two rows apart are exactly what `.nocontext` drops. At 500 sampled rows that is around five collisions, enough that the uniqueness check three lines further down — annotated `# true`, and introduced by the sentence "a duplicate would pair a generation with another question's verdict" — would have printed `false` almost every time.

Aliases are now collapsed case-insensitively too, which is what the comment beside them always claimed. Measured on real rows: `tc_267` goes from 60 aliases to 58 under the old filter, with case-only duplicates surviving.

## The WebQuestions variant is a full command now

"Changes only these two lines" was wrong — the repo id, the config and the split all change. Worse, `jq` has no error for reading a field that is not there: run against rows of the wrong shape it exited 0 and emitted `short_answer: null`, which reaches the judge as an empty string and grades every answer against nothing. Hours of GPU time spent before anything looks odd. A `select` on the answer list makes the same mistake produce an empty file instead.

## Three claims the code does not support

- **The weights/`k` mismatch** was quoted as verbatim output, so a reader matches it against their terminal. The real message names feature counts rather than rank counts, and names the file.
- **A 5-fold cross-validation failure and a `--folds` flag.** That flag was real — `scripts/evaluate_detector.py` had it, until `94c47d4` swapped the folds for an out-of-bag bootstrap and `73a4df1` folded that script into `train_detector.py` — so the entry went stale rather than being invented. The entry now covers the two errors the stage can actually raise, and stops offering `--test_size 0` as the remedy for both: it answers only the holdout error. Against a single-class label set it skips the guard entirely and moves the failure into scikit-learn, which raises about solvers rather than about labels.
- **"Every stage reads `questions.json`"** was not true of any stage after the fourth. Steps 2 and 4 read it; from there `question_id` travels on as `custom_id`, and `train_detector.py` never opens the pack at all.

## Also

The judge prompt's byte-identity test gains a 40-alias question. It was held to 0, 1 and 2 aliases, which is no longer the shape step 1 produces — TriviaQA questions carry a dozen and up to sixty. `build_judge_requests.sh` pointed at `tests/test_ecir_prompts.py`, which does not exist under that name. And `scripts/ecir/rows.jsonl`, the intermediate step 1 dumps, is gitignored.

## Checks

- 233 tests pass; all pre-commit hooks pass.
- Both `jq` programs executed against rows built from the real TriviaQA schema, including a duplicate pair, an empty alias list, and a question containing unicode, quotes, `&` and a backslash — all round-trip intact.
- Rebased onto `main` after #332 landed; merges with no conflicts.

Not verified here: `huggingface.co` is blocked from this environment, so `load_dataset` itself was not run — the schema and the split sizes come from the dataset's own card, and the arithmetic above is from those numbers.

One thing I did **not** touch, because it is one commit old and not mine: `65db83e` stopped accepting bare completions, but five `jq` snippets in this README still read `(.response.body // .response)`. Widening this PR into that felt wrong; flagging it instead.

Not labelled `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
