### PR TITLE
fix(scoring): name EntropyTransformer.fit parameters X and y

### DIFF
--- a/src/artefactual/scoring/entropy_methods/entropy_transformer.py
+++ b/src/artefactual/scoring/entropy_methods/entropy_transformer.py
@@ -80,7 +80,7 @@ class EntropyTransformer(BaseEstimator, TransformerMixin, EntropyContributionsMi
         tags.input_tags.allow_nan = True  # consumes NaN-padded input on purpose (else check_estimators_nan_inf fails)
         return tags
 
-    def fit(self, _x, _y=None) -> "EntropyTransformer":
+    def fit(self, X, y=None) -> "EntropyTransformer":  # noqa: ARG002, N803 — X / y unused but required by the sklearn fit signature
         """No-op, present so the step composes in a `Pipeline`. Returns self."""
         return self
 

--- a/tests/test_estimator_contracts.py
+++ b/tests/test_estimator_contracts.py
@@ -6,6 +6,7 @@ sklearn itself would run, restricted to the ones that make sense for estimators 
 deliberately opt out of array validation.
 """
 
+import inspect
 import warnings
 
 import numpy as np
@@ -102,6 +103,15 @@ def test_parser_opts_out_of_array_validation():
     assert tags.no_validation is True
     assert tags.requires_fit is False
     assert tags.input_tags.two_d_array is False
+
+
+@pytest.mark.parametrize("estimator", [EntropyTransformer(), LogProbParser()])
+def test_fit_names_its_two_arguments_x_and_y(estimator):
+    # sklearn reads `fit`'s signature by name, not by position: `check_estimator` fails on
+    # any other spelling before it runs a single behavioural check, and `Pipeline` passes
+    # `y` through by keyword when a later step needs it.
+    parameters = list(inspect.signature(estimator.fit).parameters)
+    assert parameters[:2] == ["X", "y"]
 
 
 # --- reduction shapes ------------------------------------------------------------------


### PR DESCRIPTION
`EntropyTransformer.fit` was declared `fit(self, _x, _y=None)`. scikit-learn reads `fit`'s signature by name, so `check_estimator` refuses the estimator on the spelling before it runs a single behavioural check:

```
AssertionError: Expected y or Y as second argument for method fit of
EntropyTransformer. Got arguments: ['_x', '_y'].
```

The underscore prefixes silenced an unused-argument lint at the cost of the contract. `LogProbParser` already solves this the other way — `def fit(self, X, y=None)` with a `# noqa: ARG002, N803` — so the two transformers were inconsistent with each other; they now match.

## Test

`test_fit_names_its_two_arguments_x_and_y` reads the signature with `inspect` and is parametrised over both transformers, so the parser's compliance is pinned alongside the transformer's. It fails on `['_x', '_y']` before this change and passes after.

## Out of scope

The second failure the issue describes — `check_estimator` feeding 2D arrays to a transformer whose data model is 3D — is a design decision, not a naming slip, and is left open. Running `check_estimator` in the suite at all is #245, which this unblocks.

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
