### PR TITLE
fix(preprocessing)!: report a malformed payload as a validation error

### DIFF
--- a/src/artefactual/preprocessing/parser.py
+++ b/src/artefactual/preprocessing/parser.py
@@ -30,6 +30,50 @@ _RESPONSE_ADAPTER = TypeAdapter(ChatCompletion | ResponsesPayload | BatchRequest
 _PAYLOAD_ADAPTER = TypeAdapter(ChatCompletion | ResponsesPayload)
 
 
+def _validate_response(outputs: Any) -> ChatCompletion | ResponsesPayload | BatchRequestOutput:
+    """Validate a payload against the completion formats, telling the two failures apart.
+
+    A payload that matches no format is not a completion response, which is a `TypeError`
+    about the input's kind. A payload that *is* recognisably one but carries bad data is a
+    validation failure, and pydantic's own report names the offending field; flattening it
+    into "unsupported format" would send the reader looking for an unsupported provider
+    instead.
+
+    A union member counts as recognised only once it reaches *inside* the structure a
+    format describes. A top-level key that is absent, or present carrying the wrong kind
+    of value, says nothing about the payload's intent -- an arbitrary mapping that happens
+    to hold a key named `output` is not a Responses payload with one bad field.
+
+    Args:
+        outputs: A single completion response, as a mapping or an object.
+
+    Returns:
+        The validated response, as whichever member of the union matched.
+
+    Raises:
+        TypeError: If the payload matches no completion format.
+        ValidationError: If it matches one and a field inside it is invalid.
+    """
+    try:
+        return _RESPONSE_ADAPTER.validate_python(outputs, from_attributes=True)
+    except ValidationError as error:
+        if _matched_a_format(error):
+            raise
+        msg = f"Unsupported output format: {type(outputs).__name__}. Expected a completion response carrying logprobs."
+        raise TypeError(msg) from error
+
+
+def _matched_a_format(error: ValidationError) -> bool:
+    """Whether some union member reached inside the payload before failing.
+
+    Errors are located as `(member, field, ...)`. Depth one is the member refusing the
+    input's type outright; depth two is a top-level key absent or holding the wrong kind of
+    value, which any unrelated mapping can produce by coincidence. Only a failure below
+    that names a payload a member walked into and objected to.
+    """
+    return any(len(item["loc"]) > 2 for item in error.errors())
+
+
 def _payload_of(record: BatchRequestOutput) -> ChatCompletion | ResponsesPayload:
     """The payload a batch line carries, refusing a line that carries none.
 
@@ -232,18 +276,16 @@ def parse_top_logprobs(outputs: Any) -> list[dict[int, list[float]]]:
         position is still counted so token indices track the generated text.
 
     Raises:
-        TypeError: If the output is not a recognised completion format, including a batch
-            line whose body is not one.
+        TypeError: If the output matches no completion format, including a batch line
+            whose body matches none.
+        ValidationError: If it matches one but carries an invalid field, named by the
+            error pydantic raised.
         ValueError: If a batch line carries no completion, because its request failed.
     """
     if is_bearable(outputs, list | tuple):
         return [sequence for response in outputs for sequence in parse_top_logprobs(response)]
 
-    try:
-        response = _RESPONSE_ADAPTER.validate_python(outputs, from_attributes=True)
-    except ValidationError as error:
-        msg = f"Unsupported output format: {type(outputs).__name__}. Expected a completion response carrying logprobs."
-        raise TypeError(msg) from error
+    response = _validate_response(outputs)
 
     # A batch line is an envelope around one of the formats below, not a fourth one,
     # so it is opened here and the extractors stay keyed to what they actually read.
@@ -265,15 +307,13 @@ def parse_sampled_token_logprobs(outputs: Any) -> list[np.ndarray]:
         One 1-D array per sequence, holding the sampled token logprobs in order.
 
     Raises:
-        TypeError: If the output is not a recognised completion format, including a batch
-            line whose body is not one.
+        TypeError: If the output matches no completion format, including a batch line
+            whose body matches none.
+        ValidationError: If it matches one but carries an invalid field, named by the
+            error pydantic raised.
         ValueError: If a batch line carries no completion, because its request failed.
     """
-    try:
-        response = _RESPONSE_ADAPTER.validate_python(outputs, from_attributes=True)
-    except ValidationError as error:
-        msg = f"Unsupported output format: {type(outputs).__name__}. Expected a completion response carrying logprobs."
-        raise TypeError(msg) from error
+    response = _validate_response(outputs)
 
     # A batch line is an envelope around one of the formats below, not a fourth one,
     # so it is opened here and the extractors stay keyed to what they actually read.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,7 @@ import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
+from pydantic import ValidationError
 
 from artefactual.preprocessing.parser import (
     LogProbParser,
@@ -113,6 +114,21 @@ def test_unsupported_payloads_are_rejected_by_both_entry_points(payload):
         parse_top_logprobs(payload)
     with pytest.raises(TypeError, match="Unsupported output format"):
         parse_sampled_token_logprobs(payload)
+
+
+# A payload that matches no schema and one that matches a schema but carries bad data are
+# different failures: the first names an unsupported provider, the second a field the
+# caller can go and fix. Reporting both as "unsupported output format" sends the reader
+# looking for the wrong problem.
+
+MALFORMED = {"choices": [{"logprobs": {"content": [{"top_logprobs": [{"logprob": "abc"}]}]}}]}
+
+
+@pytest.mark.parametrize("parse", [parse_top_logprobs, parse_sampled_token_logprobs])
+def test_a_recognised_payload_with_bad_data_names_the_field(parse):
+    with pytest.raises(ValidationError) as failure:
+        parse(MALFORMED)
+    assert any(error["loc"][-1] == "logprob" for error in failure.value.errors())
 
 
 def test_a_content_part_without_logprobs_is_skipped():


### PR DESCRIPTION
Both parse entry points raised the same `TypeError` for two unrelated failures:

| Input | What it is | Was | Now |
|---|---|---|---|
| `"nope"` | not a completion response | `TypeError: Unsupported output format: str` | unchanged |
| `{"choices": [{"logprobs": {"content": [{"top_logprobs": [{"logprob": "abc"}]}]}}]}` | a completion response with an invalid field | `TypeError: Unsupported output format: dict` | `ValidationError` naming `choices.0.logprobs.content.0.top_logprobs.0.logprob` |

Pydantic knew exactly which field failed; the old code flattened that into "unsupported format" and kept the detail only as `__cause__`, pointing the reader at an unsupported provider instead of a field they can fix.

## How the two are told apart

The union is undiscriminated, so the discriminator is the **depth of the error location**. A member counts as recognised only when it failed *below* the top-level key:

| Payload | Deepest `loc` | Verdict |
|---|---|---|
| `"nope"` | `('ChatCompletion',)` | no member accepted the type → `TypeError` |
| `{"unrelated": 1}` | `('ChatCompletion', 'choices')` missing | no top-level key present → `TypeError` |
| `{"output": ""}` | `('ResponsesPayload', 'output')` wrong type | key by coincidence, not intent → `TypeError` |
| the malformed one above | `(..., 'top_logprobs', 0, 'logprob')` | a member walked in and objected → re-raise |

That third row is not hypothetical — the existing Hypothesis property test over arbitrary Langfuse trace outputs (`test_a_trace_without_logprobs_is_rejected`) generated `{'output': ''}` against a looser first draft of this rule and rejected it. Langfuse traces carry arbitrary mappings, so a rule that called any matching key name "recognised" would turn ordinary traces into validation errors.

## Breaking

A malformed but recognisable payload now raises `ValidationError` where it raised `TypeError`. Both docstrings and the two `*_unsupported` tests are updated; a payload matching no format is unchanged. Flagged `fix!` with a `BREAKING CHANGE:` footer so git-cliff carries it into the release notes.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)
