### PR TITLE
ci(release): allow a manual release of main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,9 +7,14 @@ name: Release
 # The chain runs inside one workflow. Chaining through `workflow_run` on a pushed tag
 # would never fire: a push made with GITHUB_TOKEN does not start a workflow run, so the
 # tag would appear and nothing would build.
+#
+# A commit already on main can still be released, by running this workflow by hand: the
+# label is read off a pull request, so a merge that carried none has no second chance
+# otherwise, and opening a throwaway pull request to carry a label is not one.
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -34,14 +39,32 @@ jobs:
       # commit and its labels read back. A commit that belongs to no pull request -- a
       # direct push to main -- releases nothing, which is the safe default: a version
       # number is spent permanently and cannot be reissued.
+      #
+      # Run by hand, the request itself is the decision and there is no pull request to
+      # read. Starting a workflow needs write access, and the pypi environment still holds
+      # its required reviewer, so this is a second way to ask, not a way around the gate.
+      # Refused off main: the tag is created on HEAD, and a tag on a side branch is not
+      # reachable by `git describe` from main, which is what hatch-vcs reads the version
+      # back from.
       - name: Look for the release label on the merged pull request
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
+          EVENT: ${{ github.event_name }}
+          REF: ${{ github.ref }}
         run: |
           set -euo pipefail
+          if [ "$EVENT" = workflow_dispatch ]; then
+            if [ "$REF" != refs/heads/main ]; then
+              echo "::error::a manual release runs from main only, not $REF"
+              exit 1
+            fi
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "started by hand from main: tagging and publishing"
+            exit 0
+          fi
           labels=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '[.[].labels[].name] | join(" ")')
           echo "labels on the merged pull request: ${labels:-<none>}"
           if printf '%s' "$labels" | tr ' ' '\n' | grep -qx release; then
@@ -87,6 +110,17 @@ jobs:
       - name: Compute and create the next tag
         id: bump
         run: |
+          # Two triggers reach this job, and the concurrency group serialises them rather
+          # than rejecting the second: a hand-started run queued behind a labelled merge
+          # would bump again off the same HEAD and spend a second version number on an
+          # identical tree, with an empty changelog between the two tags. A commit that is
+          # already tagged has already been released, so this stops rather than releasing
+          # it twice -- a version number cannot be reissued, and the fix for a missed
+          # release is another dispatch, not another tag on the same commit.
+          if tagged=$(git describe --tags --exact-match HEAD 2>/dev/null); then
+            echo "::error::HEAD is already released as $tagged; nothing to tag"
+            exit 1
+          fi
           # Annotated tags carry a tagger, which a runner has no identity for by default.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,18 +50,43 @@ This project uses [CalVer](https://calver.org/) versioning with the format `YYYY
 
 ### Creating a Release
 
-A merge to `main` releases when its pull request carried the **`release`** label, and does
-nothing otherwise. There is no tag to push and no version to edit: the version lives in the
-git tag, and the tag is created by CI.
+There is no tag to push and no version to edit: the version lives in the git tag, and the
+tag is created by CI. Two things start it.
 
-Label the pull request before merging it:
+**Land the changes, then say when.** Nothing about a merge releases by itself, so the
+pull requests go in normally and the release is a separate decision, taken once they are
+all on `main`:
+
+```bash
+gh workflow run release.yaml --ref main
+```
+
+Starting a workflow needs write access and the `pypi` environment still holds its required
+reviewer, so this is a way to ask rather than a way around the gate. It refuses any ref but
+`main`: the tag is created on `HEAD`, and a tag on a side branch is not reachable by
+`git describe` from `main`, which is where `hatch-vcs` reads the version back from. A
+`HEAD` that already carries a tag is refused too — that commit has been released, and a
+second tag on it would spend a version number on an identical tree.
+
+**Or decide at merge time**, with the **`release`** label on the pull request. A merge to
+`main` releases when the pull request it came from carried the label, and does nothing
+otherwise:
 
 ```bash
 gh pr edit <number> --add-label release
 ```
 
+This is the shorter path when one pull request is the whole release. It is also the one
+that has to be remembered in the middle of merging, and the label is not visible in the
+diff being reviewed, so prefer it for a single change and dispatch for a batch.
+
 Ordinary merges publish nothing, so a fix to a fix does not spend a version number. A
 commit pushed straight to `main`, belonging to no pull request, never releases.
+
+Do not start a dispatch while a labelled merge is still releasing: the two are serialised
+rather than rejected, so the second would run against whatever `main` is by then. The tag
+job refuses an already-released `HEAD`, which catches the common case, but the Actions tab
+is the thing to check first.
 
 `bump-my-version` computes the next tag from the most recent reachable one and creates it,
 configured to write no files and make no commit. `hatch-vcs` then reads the version back
@@ -71,10 +96,12 @@ off that tag at build time, so what is tagged and what is built cannot disagree 
 The chain runs in one workflow, because a tag pushed with `GITHUB_TOKEN` does not start a
 workflow run: chaining on the tag would leave the tag created and nothing built.
 
-    merge to main
-      -> gate             is the merged pull request labelled `release`?
+    `gh workflow run release.yaml --ref main`, or a merge to main
+      -> gate             a dispatch is the decision itself; a merge releases only if
+                          the pull request it came from carried `release`
       -> tests            the suite, against the exact commit being released
-      -> tag              bump-my-version creates vYYYY.MM.PATCH
+      -> tag              bump-my-version creates vYYYY.MM.PATCH, refusing a HEAD
+                          that already carries one
       -> build            hatch-vcs derives the version; the distributions are checked
                           and the wheel is smoke-tested
       -> publish-testpypi uploaded, then checked against the metadata the index serves


### PR DESCRIPTION
The `release` label is read off the pull request a commit was merged from. That makes the normal path sound — the thing tagged is the thing that was reviewed and CI-gated — but it leaves a gap with no way out: **a commit already on `main` cannot be released.** Forget the label, or decide to ship the morning after, and the only recourse today is opening a throwaway pull request whose whole purpose is to carry a label.

```bash
gh workflow run release.yaml --ref main
```

## This becomes the recommended path, not just the fallback

The label has to be applied in the middle of merging, and it is not visible in the diff being reviewed. For a release of more than one change it also forces a guess about *which* pull request merges last. Landing everything and then saying when is strictly simpler, so `CONTRIBUTING.md` now leads with the dispatch and keeps the label as the shorter path for when one pull request is the whole release.

## Why this is not a hole in the gate

| | Merge path | Manual path |
|---|---|---|
| Who can start it | anyone who can merge | anyone with write access |
| Tests against the released commit | yes | yes — same `tests` job, unchanged |
| TestPyPI upload checked against served metadata | yes | yes |
| `pypi` environment required reviewer | yes | yes |

`tests.yaml` was checked rather than assumed: it reads no `github.event.*` and no `pull_request` context, and the release workflow already calls it on `push`, which is not a pull-request event either. The `tag` job's checkout pins no `ref:`, so a dispatch checks out `main`.

## The ref guard

A dispatch from any ref but `main` fails the gate with an error rather than releasing. `bump-my-version` tags `HEAD`; a tag created on a side branch is not reachable by `git describe` from `main`, which is exactly what `hatch-vcs` reads the version back from at build time — so the tag and the build would disagree, which is the one property this pipeline is built to guarantee.

## The collision the second trigger makes possible

`concurrency: {group: release-main, cancel-in-progress: false}` serialises rather than rejects. With one trigger that was enough. With two, a dispatch started while a labelled merge is releasing does not fail — it **queues**, then runs, bumps again off the same `HEAD`, and spends a second version number on an identical tree with an empty changelog between the tags.

So the `tag` job now refuses a `HEAD` that already carries one:

```bash
if tagged=$(git describe --tags --exact-match HEAD 2>/dev/null); then
  echo "::error::HEAD is already released as $tagged; nothing to tag"
  exit 1
fi
```

That catches the case where nothing landed in between. If something *did* land, the queued run releases it legitimately — so `CONTRIBUTING.md` also says not to dispatch while a release is running, and to check the Actions tab first. The guard is in this PR rather than a follow-up because this PR is what creates the second trigger.

## Considered and rejected

A release-please style bot maintaining a standing "release PR" — it wants a version string committed in the repository, and this project deliberately has none. The version exists only in the tag, which is what makes *what was tagged* and *what was built* unable to disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
