### PR TITLE
fix(sklearn): order the transformer bases so the tags resolve

### DIFF
--- a/src/artefactual/preprocessing/parser.py
+++ b/src/artefactual/preprocessing/parser.py
@@ -136,7 +136,11 @@ def _(response: ResponsesPayload) -> list[np.ndarray]:
     return sampled_tokens_logprobs_responses_api(response)
 
 
-class LogProbParser(BaseEstimator, TransformerMixin):
+# Base order is significant. `__sklearn_tags__` resolves through `super()`, so
+# `TransformerMixin` must precede `BaseEstimator` for the mixin's override to run. In the
+# reverse order `transformer_tags` stays `None` and scikit-learn does not treat the class
+# as a transformer.
+class LogProbParser(TransformerMixin, BaseEstimator):
     """First pipeline step: completion responses in, a dense logprob array out.
 
     Accepts raw responses rather than arrays, so it opts out of scikit-learn's input

--- a/src/artefactual/scoring/entropy_methods/entropy_transformer.py
+++ b/src/artefactual/scoring/entropy_methods/entropy_transformer.py
@@ -55,7 +55,9 @@ def _wepr(x, axis) -> np.ndarray:
 STRATEGIES = {"epr": _epr, "wepr": _wepr}
 
 
-class EntropyTransformer(BaseEstimator, TransformerMixin, EntropyContributionsMixin):
+# Base order is significant. `__sklearn_tags__` resolves through `super()`, so
+# `TransformerMixin` must precede `BaseEstimator` for `transformer_tags` to be set.
+class EntropyTransformer(TransformerMixin, BaseEstimator, EntropyContributionsMixin):
     """Reduce per-rank entropy contributions to the features a calibration was fit on.
 
     Input is the `(n_sequences, n_tokens, k)` array `LogProbParser` emits, NaN-padded on
@@ -78,6 +80,12 @@ class EntropyTransformer(BaseEstimator, TransformerMixin, EntropyContributionsMi
         tags = super().__sklearn_tags__()
         tags.requires_fit = False  # stateless: fit learns nothing from data
         tags.input_tags.allow_nan = True  # consumes NaN-padded input on purpose (else check_estimators_nan_inf fails)
+        # Input is three-dimensional: `transform` reduces the token axis and the reduction
+        # reduces the rank axis, and the two coincide below three dimensions. The tags select
+        # which arrays scikit-learn's checks synthesise, and the only producer of this step's
+        # input, `LogProbParser`, emits `(n_sequences, n_tokens, k)`.
+        tags.input_tags.two_d_array = False
+        tags.input_tags.three_d_array = True
         return tags
 
     def fit(self, X, y=None) -> "EntropyTransformer":  # noqa: ARG002, N803 — X / y unused but required by the sklearn fit signature

--- a/tests/test_estimator_contracts.py
+++ b/tests/test_estimator_contracts.py
@@ -274,3 +274,26 @@ def test_padded_sequences_still_warn():
         features = EntropyTransformer(reduction="epr").transform(padded)
 
     assert not features.any()
+
+
+# --- sklearn tags ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("estimator", [EntropyTransformer(), LogProbParser()])
+def test_the_transformer_tags_resolve(estimator):
+    # `__sklearn_tags__` walks the MRO through `super()`, so `TransformerMixin` has to come
+    # before `BaseEstimator` for its override to run at all. In the other order the chain
+    # reaches `BaseEstimator`'s implementation first, `transformer_tags` is left None, and
+    # scikit-learn stops treating the class as a transformer -- silently, since nothing
+    # raises and `transform` still works when called directly.
+    assert estimator.__sklearn_tags__().transformer_tags is not None
+
+
+def test_the_entropy_transformer_declares_three_dimensional_input():
+    # `transform` reduces the token axis and the reduction reduces the rank axis; below
+    # three dimensions the two coincide. The tag decides which arrays sklearn's own checks
+    # synthesise, and the only producer of this step's input, LogProbParser, emits
+    # (n_sequences, n_tokens, k).
+    tags = EntropyTransformer().__sklearn_tags__()
+    assert tags.input_tags.two_d_array is False
+    assert tags.input_tags.three_d_array is True


### PR DESCRIPTION
Salvaged from a month-old chain (`fix(sklearn): make both pipeline steps conform to the transformer contract`) that no longer rebases — every commit in it conflicts with `main` after #335. This re-applies the half that is still correct and drops the half that would break the build.

## The bug, on today's `main`

```python
LogProbParser().__sklearn_tags__().transformer_tags      # None
EntropyTransformer().__sklearn_tags__().transformer_tags # None
```

Both classes listed `BaseEstimator` before `TransformerMixin`. `__sklearn_tags__` resolves through `super()`, so in that order the chain reaches `BaseEstimator`'s implementation first and the mixin's override never runs — scikit-learn stops treating either class as a transformer. Nothing raises and `transform` still works when called directly, which is why it survived this long.

## Also

`EntropyTransformer` declares its input three-dimensional. `transform` reduces the token axis and the reduction reduces the rank axis, and the two coincide below three dimensions, so the 2D arrays sklearn's checks synthesise exercise a shape the step never receives — its only producer, `LogProbParser`, emits `(n_sequences, n_tokens, k)`.

Both are prerequisites for running `check_estimator` in the suite at all, which is #245 — already unblocked on the signature side by #336.

## Deliberately not carried over

The original commit also rewrote `# noqa: ARG002, N803` back to `# ruff: ignore[unused-method-argument, invalid-argument-name]`, undoing its own chain-mate. This repository pins ruff 0.14.11, which reports RUF103 on that syntax — `.pre-commit-config.yaml` documents the trap, where nbqa's floating ruff 0.16 kept migrating them. Merging that half would turn pre-commit red on `main`.

## Verification

`331 passed, 2 skipped`; pre-commit clean. Three tests added, all failing before the change: `transformer_tags` resolves for both estimators, and the 2D/3D input tags.

Refs #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
