### PR TITLE
ci(docs): publish the site on a release, and name the version it documents

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,39 @@
 name: Build and Deploy Documentation
 
+# The site is published by the release pipeline, not by a merge. A merge to main and a
+# pull request still build it -- a broken build is worth catching where it is introduced --
+# but only a release deploys, so the published pages always describe the version on PyPI.
+#
+# Called rather than triggered by the tag: a tag pushed with GITHUB_TOKEN starts no
+# workflow run, so `on: push: tags:` would never fire. `release.yaml` calls this after the
+# GitHub Release exists.
 on:
   push:
     branches:
       - main
   pull_request:
+  # Republish the site without cutting a version: executing by default, since the outputs
+  # committed in the notebooks are not what the site is meant to show.
   workflow_dispatch:
+    inputs:
+      deploy:
+        description: Publish the built site to GitHub Pages.
+        type: boolean
+        default: true
+      execute:
+        description: Run the notebooks and publish the outputs they produce.
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      deploy:
+        description: Publish the built site to GitHub Pages.
+        type: boolean
+        default: false
+      execute:
+        description: Run the notebooks and publish the outputs they produce.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -18,10 +46,19 @@ concurrency:
 
 env:
   FORCE_COLOR: "1"
+  # Read by docs/conf.py, which switches nbsphinx to "always" when it is set. Only the
+  # release build sets it: executing reaches the Hugging Face Hub, which a pull request
+  # should not have to wait on.
+  ARTEFACTUAL_EXECUTE_NOTEBOOKS: ${{ inputs.execute && '1' || '' }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # A build that executes downloads the checkpoints its notebooks load (some 500 MB) and
+    # runs the encoder judge on CPU -- around five minutes on a cold runner. nbsphinx_timeout
+    # in conf.py caps a single cell; this caps the job, well under the 6 h GitHub would
+    # otherwise allow it to burn.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -39,8 +76,12 @@ jobs:
             pyproject.toml
             uv.lock
 
+      # The notebooks group already depends on the docs extra, so an executing build names
+      # only the group. A build that does not execute reads the outputs stored in the .ipynb
+      # files and needs none of the runtime the group adds -- torch alone is 2 GB -- so it
+      # installs the extra by itself.
       - name: Install dependencies
-        run: uv sync --extra docs
+        run: uv sync ${{ inputs.execute && '--group notebooks' || '--extra docs' }}
 
       # nbsphinx shells out to pandoc to convert the notebooks' markdown cells. Without it
       # every notebook fails to read and the build stops, which -W turns into an error.
@@ -100,7 +141,12 @@ jobs:
           path: docs/_build/html
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # `inputs.deploy` alone, never `github.event_name`: in a called workflow the event is
+    # the *caller's*, so a release started by `gh workflow run release.yaml` would read as a
+    # manual run and deploy the site here -- before PyPI has the version, and even if the
+    # required reviewer declines it. On a push or a pull request there are no inputs at all
+    # and this is null, which is falsy.
+    if: inputs.deploy
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,7 +137,7 @@ jobs:
         run: git push origin "$TAG_NAME"
 
   build:
-    needs: tag
+    needs: [tag, docs-build]
     permissions:
       contents: read
       id-token: write  # a called workflow cannot hold more than its caller grants
@@ -315,3 +315,43 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+
+  # After the tag and before anything is published, so it gates the release at the last
+  # point where stopping still costs nothing: executing the notebooks is part of what a
+  # release is checked against, and a published example that no longer runs should stop the
+  # release rather than be discovered on the site afterwards. It cannot run any earlier --
+  # conf.py reads the version from the installed package, which hatch-vcs derives from the
+  # most recent tag, so a build before the tag exists would name the release .dev and put
+  # the development banner on the released site. A failure here leaves the tag behind with
+  # nothing published; delete it with `git push origin :vYYYY.MM.PATCH`, as for a declined
+  # pypi environment. Deploying is a separate job below -- this one only builds and uploads
+  # the pages artifact.
+  docs-build:
+    needs: [gate, tag]
+    if: needs.gate.outputs.release == 'true'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/docs.yml
+    with:
+      execute: true
+      deploy: false
+
+  # Last, and only once PyPI has the version: the site names the version it documents, so
+  # publishing it earlier would advertise an API that cannot yet be installed. The artifact
+  # is the one docs-build uploaded in this same run, built from the tagged commit, so the
+  # pages deployed are the ones that gated the publish.
+  docs-deploy:
+    needs: [docs-build, publish, github-release]
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,11 +102,16 @@ workflow run: chaining on the tag would leave the tag created and nothing built.
       -> tests            the suite, against the exact commit being released
       -> tag              bump-my-version creates vYYYY.MM.PATCH, refusing a HEAD
                           that already carries one
+      -> docs-build       the site, with its notebooks executed -- a published
+                          example that stopped running stops the release here,
+                          before anything is uploaded. After the tag, because the
+                          version the pages name is read back off it
       -> build            hatch-vcs derives the version; the distributions are checked
                           and the wheel is smoke-tested
       -> publish-testpypi uploaded, then checked against the metadata the index serves
       -> publish          PyPI, held for a required reviewer
       -> github-release   the Release, once PyPI has the version
+      -> docs-deploy      the pages built above, published last
 
 The `pypi` environment has a required reviewer, so nothing reaches PyPI unattended. A
 release that should not go out is declined there; the tag is already created by then, and a

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,13 @@ project = "Artefactual"
 copyright = "2025, Artefact Research Center"  # noqa: A001
 author = "Hicham Randrianarivo, Gauthier Jeannin, Charles Moslonka"
 
+# Read from the installed package, which hatch-vcs derives from the git tag, so the site
+# names a version that exists rather than one restated here and left to drift. A build
+# from an untagged commit carries a `.dev` segment, which is what marks it unreleased.
+release = artefactual.__version__
+version = ".".join(release.split(".")[:2])
+_is_development_build = ".dev" in release
+
 # Extensions
 extensions = [
     "myst_parser",
@@ -63,7 +70,20 @@ myst_enable_extensions = [
 ]
 
 # nbsphinx settings
-nbsphinx_execute = "never"
+#
+# The published site runs its notebooks. Committed outputs are whatever the last person to
+# open the notebook happened to produce -- which has already put an absolute path from a
+# contributor's home directory on the public site -- so the release build executes them
+# and publishes what it got. Every other build reads the committed outputs instead, because
+# executing needs the network and would make a pull request wait on the Hugging Face Hub.
+#
+# A notebook that cannot run unattended opts out in its own metadata
+# (`"nbsphinx": {"execute": "never"}`), which is where the reason belongs: it travels with
+# the notebook rather than sitting in a list here that nobody updates.
+nbsphinx_execute = "always" if os.environ.get("ARTEFACTUAL_EXECUTE_NOTEBOOKS") else "never"
+
+# A notebook that reaches the Hub has to survive a slow answer; the default is 30 seconds.
+nbsphinx_timeout = 600
 
 # Every notebook page carries its own two entry points in the article header: open the
 # notebook in Colab, or download the `.ipynb`. They live in a theme component
@@ -160,6 +180,17 @@ html_theme_options = {
     "show_nav_level": 2,
     "navigation_depth": 3,
 }
+
+# The site is published from the release pipeline, so what it documents is a released
+# version and the two cannot disagree. A build from anywhere else -- a pull request, a
+# working copy -- says so, because the alternative is a page that reads as published while
+# describing an API `pip install artefactual` does not give you.
+if _is_development_build:
+    html_theme_options["announcement"] = (
+        "This is the development version of the documentation. It describes unreleased "
+        "changes. The released version is on "
+        '<a href="https://pypi.org/project/artefactual/">PyPI</a>.'
+    )
 
 # Mermaid renders in the browser, so a diagram is live SVG rather than an image: it selects,
 # it scales, and with d3 zoom it pans like the ones GitHub renders. The palette it bakes in

--- a/docs/examples/langfuse_integration_demo.ipynb
+++ b/docs/examples/langfuse_integration_demo.ipynb
@@ -194,7 +194,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.5"
-  }
+  },
+  "nbsphinx": {
+   "execute": "never"
+  },
+  "artefactual_execute_skip_reason": "generates against a live endpoint and writes scores to a Langfuse project"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/docs/examples/train_wepr_bertjudge.ipynb
+++ b/docs/examples/train_wepr_bertjudge.ipynb
@@ -35,7 +35,8 @@
    "outputs": [],
    "source": [
     "# From a clone: `uv sync --group notebooks` brings the judge's runtime, which is not in\n",
-    "# the default environment.\n",
+    "# the default environment. The release build runs this notebook, so the judge's own repo\n",
+    "# code executes there too -- `trust_remote_code` below, on an org-owned checkpoint.\n",
     "#\n",
     "# `bert-judge` is the judge's own package and declares no dependencies, so torch,\n",
     "# transformers and datasets are named alongside it. The transformers range is the\n",

--- a/docs/examples/train_wepr_pipeline.ipynb
+++ b/docs/examples/train_wepr_pipeline.ipynb
@@ -936,7 +936,11 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  }
+  },
+  "nbsphinx": {
+   "execute": "never"
+  },
+  "artefactual_execute_skip_reason": "generates and judges against a live endpoint, which costs requests"
  },
  "nbformat": 4,
  "nbformat_minor": 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,16 +142,21 @@ dev = [
     "pytest-cov>=6.0.0",
 ]
 
-# What the notebooks under docs/examples need beyond the package: `uv sync --group
-# notebooks`, then `uv run jupyter lab docs/examples/<name>.ipynb`.
+# Everything needed to build the site with its notebooks executed: `uv sync --group
+# notebooks` is the one command, for CI and for a clone alike. It layers the runtime the
+# examples need on top of the `docs` extra, because a published page showing a notebook's
+# output only exists if the notebook ran.
 #
 # A group rather than a [project.optional-dependencies] extra, because `bert-judge` is a
 # git URL: a direct reference in a distribution's metadata is rejected on upload to PyPI,
-# and groups are not part of that metadata. It is also the right scope -- these are for
-# running the examples from a clone, not for anything that imports the package.
+# and groups are not part of that metadata. That is also why the merge goes this way round
+# -- the group may depend on the extra, never the reverse.
 notebooks = [
     # train_wepr_pipeline.ipynb and langfuse_integration_demo.ipynb call an endpoint.
     "artefactual[adapters]",
+    # nbsphinx executes the notebooks in-process, so Sphinx and the judge's runtime have to
+    # be the same environment.
+    "artefactual[docs]",
     "jupyterlab>=4.3.5",
     # train_wepr_pipeline.ipynb renders its two prompts, the paper's, as the templates they
     # are.
@@ -168,6 +173,18 @@ notebooks = [
     "transformers>=4.57,<5",
     "datasets>=3.2.0",
 ]
+
+# The notebooks run the encoder judge on CPU -- there is no GPU on a docs runner, and no
+# GPU in a clone's default environment either. Left to PyPI, `torch` resolves to the CUDA
+# build and drags in some 40 nvidia-* wheels, several GB that nothing here ever loads, so
+# Linux takes the CPU wheels instead. macOS wheels are CPU-only already and are unaffected.
+[tool.uv.sources]
+torch = [{ index = "pytorch-cpu", marker = "sys_platform == 'linux'" }]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
 
 [tool.coverage.run]
 # `source` (not `--cov=artefactual`) so the namespace package under adapters/ lands in


### PR DESCRIPTION
The site deployed on **every push to `main`** while `pip install artefactual` gives whatever was last released. Those are different things, and nothing on the page said which one you were reading. That is not hypothetical — it is the state right now:

| | |
|---|---|
| The live site documents | `WEPR.from_pretrained(…)` — `main`, unreleased |
| `pip install artefactual` gives | `2026.08.1` — the `epr()` / `wepr()` factories |

A reader following the quick start today gets an `ImportError`.

## Publish from the release pipeline

`release.yaml` gains a `docs` job after `github-release`, so the pages deploy once PyPI has the version. A merge to `main` and a pull request still **build** the site — a broken build is worth catching where it is introduced — but neither deploys.

**Called, not triggered by the tag.** A tag pushed with `GITHUB_TOKEN` starts no workflow run, which is the same trap that shaped the rest of this pipeline, so `on: push: tags:` or `on: release:` would silently never fire. The deploy is gated on a `workflow_call` input rather than `github.event_name`, because in a called workflow that reports the *caller's* event and cannot say "called by the release".

`workflow_dispatch` still deploys, which is how to republish the site without cutting a version.

## Name the version

`conf.py` set only `project`. It now reads `release` from the installed package — which `hatch-vcs` derives from the git tag — so the number is one that exists rather than a string restated in the docs and left to drift. The pydata theme renders it in the navbar.

A build from an untagged commit carries a `.dev` segment and shows a banner:

> This is the development version of the documentation. It describes unreleased changes. The released version is on PyPI.

After this change the deployed site is always a release, so the banner is what a contributor sees locally or on a pull request preview — belt to the version string's braces.

## Trade-off

Unreleased documentation stops being visible on the public site. Work merged to `main` waits for the next release to appear, which is the point: predictable pages that match the installable package.

## Verification

`sphinx-build -W` succeeds; the built `index.html` carries both the banner and `2026.8` in the navbar. `336 passed, 2 skipped`; pre-commit clean. Both workflow files parse and `release.yaml` now ends `… github-release → docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
