### PR TITLE
test(examples): pin the BERTJudge checkpoint and the label polarity

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -155,6 +155,29 @@ def test_the_response_fixture_is_wide_enough_to_train_on():
     assert min(widths) >= 15, f"fixture carries {min(widths)} ranks per token, the notebook fits at k=15"
 
 
+def test_the_encoder_judge_is_read_the_way_it_was_trained():
+    """Pin the two choices in the BERTJudge notebook that fail silently.
+
+    Neither is caught by running the notebook: both leave it producing numbers in the
+    right range, and every metric downstream still reads as plausible.
+
+    The checkpoint is one of a family. The Formatted siblings expect answers ending in
+    "Final answer: <x>"; scoring unconstrained generations with one grades the format
+    rather than the answer.
+
+    The polarity is inverted between the two sides. `read_judgment` answers True when the
+    judge said the response was CORRECT, and the detector's positive class is the
+    hallucination, so the label is the negation. Dropping it trains the detector to
+    recognise correct answers and reports the result as hallucination detection.
+    """
+    code = code_of(load("train_wepr_bertjudge"))
+
+    assert 'JUDGE_MODEL = "artefactory/BERTJudge"' in code, (
+        "the Free-QCR checkpoint is the one trained on unconstrained generations"
+    )
+    assert "int(not verdict)" in code, "the label is the negation of the judge's verdict"
+
+
 @pytest.mark.parametrize("name", OFFLINE_NOTEBOOKS)
 def test_the_committed_outputs_are_not_empty(name):
     """A notebook stripped of outputs renders as a blank page on the docs site."""


### PR DESCRIPTION
## What this pins

`docs/examples/train_wepr_bertjudge.ipynb` makes two choices that fail **silently** — the notebook keeps producing scores in `[0, 1]` and every metric downstream still reads as plausible, so running it catches neither.

**The checkpoint.** `artefactory/BERTJudge` is one of a family. The `Formatted` siblings expect answers ending in `Final answer: <x>`; scoring unconstrained generations with one of those grades the *answer format* rather than the answer.

**The polarity.** `read_judgment` answers `True` when the judge said the response was CORRECT, and the detector's positive class is the *hallucination*. The label is therefore the negation. Drop the `not` and you train the detector to recognise correct answers, then report the result as hallucination detection.

Two assertions over the notebook source, in `tests/test_examples.py`:

```python
assert 'JUDGE_MODEL = "artefactory/BERTJudge"' in code
assert "int(not verdict)" in code
```

## Why source assertions rather than a behavioural test

Running the notebook requires the 422 MB checkpoint and a CPU inference pass, and it would pass either way — that is the whole problem. The choices are only visible in the source, so that is where they are pinned.

An earlier version of this notebook inlined the judge and also pinned its markers and score reduction. The notebook now takes `bert_judge` as a dependency, so those belong to the package; what remains notebook-local is the checkpoint and the polarity, and only those are asserted here.

## Verified

`35 passed, 2 skipped` against current `main`; pre-commit clean.

Note this matters more now that PR #344 makes the release build **execute** the notebooks: a silently wrong judge would publish plausible-looking numbers to the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
