### PR TITLE
ci(release): update the publish action to one whose twine accepts metadata 2.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,13 @@ jobs:
       # Metadata that fails to render leaves a blank project page, and a release cannot be
       # reissued to fix it. Checked here rather than at publish time so a pull request that
       # breaks the description fails before a version number is ever spent on it.
+      # Pinned, and pinned to the major that pypa/gh-action-pypi-publish bundles: an
+      # unpinned `uvx twine` resolves the newest release, which is how a wheel once passed
+      # this check and was then rejected at upload by the action's older twine, for metadata
+      # the two versions disagreed about. A check that runs a different twine than the
+      # publisher does not check what it claims to. Move this when the action's pin moves.
       - name: Check the distributions render
-        run: uvx twine check --strict dist/*
+        run: uvx --from 'twine>=7,<8' twine check --strict dist/*
 
       # The wheel is exercised before it is published anywhere, and from an environment
       # built only from its own declared dependencies -- not the project's. A dependency

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,7 +197,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26  # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           print-hash: true
@@ -300,7 +300,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26  # v1.14.2
         with:
           print-hash: true
           attestations: true


### PR DESCRIPTION
## What broke

The 2026.09.0 release tagged and built, then failed at the TestPyPI upload:

```
Checking dist/artefactual-2026.9.0-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata:
'2.5' is not a valid metadata version
```

hatchling emits `Metadata-Version: 2.5`. twine only learned to accept it in **7.0**, and `pypa/gh-action-pypi-publish` bundled twine 6 until **v1.14.2**, whose release notes name this exactly — *"update of Twine to v7 … will let them upload their sdists and wheels containing core packaging metadata v2.5"*.

Both publish pins move from `v1.13.0` to `v1.14.2` (`a892a5a`).

## The more useful half

`build.yaml` is *supposed* to catch a packaging fault before the tag exists. It didn't, and the reason is worth fixing:

```yaml
run: uvx twine check --strict dist/*      # unpinned → resolves the NEWEST twine
```

So the gate checked with twine **7** while the publisher uploaded with twine **6**, and 6 and 7 disagree about precisely this metadata version. A check that runs a different twine than the publisher does not check what it claims to. It is now pinned to the major the action bundles, with a comment to move it when the action pin moves.

## Reproduced locally

| | result |
|---|---|
| wheel metadata | `Metadata-Version: 2.5` |
| `twine>=6,<7` (what the old action shipped) | **ERROR** — `'2.5' is not a valid metadata version` |
| `twine>=7,<8` (the new pin) | **PASSED** |

## Release state

Nothing reached either index — TestPyPI and PyPI both 404 for `2026.9.0`, and PyPI is still serving `2026.8.1`. The only trace is the tag `v2026.09.0`, which is the failure mode the pipeline is designed to accept. The tag will be deleted and reissued so the release keeps the version number it was going to have, rather than skipping to `2026.09.1`.

Everything before the upload worked, including the new pipeline from #346: gate computed the version, tests passed, **docs-build executed the notebooks**, and tag created `v2026.09.0` from the gate's string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
