### PR TITLE
fix(ci): pin the publish action to its commit, not its tag object

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,7 +197,13 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26  # v1.14.2
+        # The COMMIT a tag points at, never the annotated tag object's own sha: this is a
+        # Docker action, and the image on ghcr is tagged by commit. A tag-object sha fails
+        # at `docker run` with `manifest unknown`, after the release has already tagged.
+        # Resolve it with: gh api repos/pypa/gh-action-pypi-publish/git/ref/tags/vX.Y.Z
+        #   --jq '.object.sha'  then, if .object.type is "tag", dereference:
+        #   gh api repos/pypa/gh-action-pypi-publish/git/tags/<sha> --jq '.object.sha'
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           print-hash: true
@@ -300,7 +306,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26  # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           print-hash: true
           attestations: true


### PR DESCRIPTION
## What broke

My fix in #348 moved the publish action to v1.14.2 but named the **wrong object**. The re-release got past the metadata check and died at `docker run`:

```
Unable to find image 'ghcr.io/pypa/gh-action-pypi-publish:a892a5a6...'
docker: Error response from daemon: manifest unknown
```

`gh api .../git/ref/tags/v1.14.2 --jq '.object.sha'` returns the sha of the **annotated tag object**, not of the commit it points at. `gh-action-pypi-publish` is a **Docker** action and its ghcr image is tagged by *commit*, so the pin named an image that does not exist.

| object | sha | ghcr manifest |
|---|---|---|
| annotated tag (what #348 used) | `a892a5a6` | **404 — manifest unknown** |
| dereferenced commit | `dc37677b` | **200** |

Both pins now use `dc37677b`.

## Why only this action

It is the only Docker action in these workflows. The rest (`actions/checkout`, `astral-sh/setup-uv`, `softprops/action-gh-release`, …) are JS or composite actions, where GitHub resolves the ref itself rather than pulling a registry image — I audited every 40-hex pin and none of the others is affected.

The dereferencing recipe is written next to the pin, because this failure lands **after** the release has created its tag and costs a tag deletion each time.

## Release state

Still nothing on either index — TestPyPI and PyPI both 404 for `2026.9.0`; PyPI serves `2026.8.1`. The `v2026.09.0` tag from the second attempt has been deleted, so the next dispatch computes `2026.09.0` again rather than skipping to `.1`.

Everything up to the upload has now passed twice: gate → tests → docs-build (notebooks executed) → tag → build, plus the metadata check that #348 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
