### PR TITLE
feat(docs): keep every release online behind a version switcher

### DIFF
--- a/.github/actions/publish-site/action.yml
+++ b/.github/actions/publish-site/action.yml
@@ -1,0 +1,107 @@
+name: Publish the versioned site
+description: >-
+  Place a documentation build in the archive of every release published so far, refresh the
+  version switcher, and upload the whole tree as the GitHub Pages artifact.
+
+# Both the release pipeline and a manual docs dispatch publish the site, and they must
+# assemble it the same way: `actions/deploy-pages` replaces the entire site on every run,
+# so a caller that deployed only its own build would take every previous version offline.
+
+inputs:
+  version:
+    description: Version this build documents, as the tag spells it (zero-padded month).
+    required: true
+  site-url:
+    description: Base URL the published site is read from.
+    required: true
+  artifact:
+    description: Name of the build artifact to place in the archive.
+    required: false
+    default: site
+  token:
+    description: Token used to push the archive branch.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # `git clone`, not actions/checkout: the branch does not exist before the first
+    # versioned deploy and a composite step cannot carry continue-on-error, and checkout
+    # would leave a .git whose history the archive commit would then extend.
+    - name: Fetch the published archive
+      shell: bash
+      env:
+        TOKEN: ${{ inputs.token }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        git clone --quiet --depth 1 --branch gh-pages \
+          "https://x-access-token:${TOKEN}@github.com/${REPO}.git" site || true
+        mkdir -p site
+        rm -rf site/.git
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact }}
+        path: new-build
+
+    - name: Place this release in the archive
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        SITE_URL: ${{ inputs.site-url }}
+      run: |
+        set -euo pipefail
+        if [ -z "$VERSION" ]; then
+          echo "::error::a deploy needs the version it is publishing; the release passes it"
+          exit 1
+        fi
+        # The release is spelled two ways: the tag and the gate carry the zero-padded
+        # CalVer month (2026.09.0), while PEP 440 normalisation strips it, so the
+        # installed package -- and the `version_match` the theme compares against --
+        # says 2026.9.0. The site uses the package's spelling, or the dropdown never
+        # marks the version being read as current.
+        VERSION=$(python3 "$GITHUB_ACTION_PATH/../../scripts/build_switcher.py" canonical "$VERSION")
+        echo "publishing as $VERSION"
+
+        rm -rf "site/$VERSION"
+        cp -r new-build "site/$VERSION"
+
+        # `stable` is what documentation links point at, so it must not move to a new URL
+        # each release: it is a copy of the newest one, not a redirect, so that every
+        # relative link inside the site keeps working when read from under it.
+        rm -rf site/stable
+        cp -r new-build site/stable
+
+        # Generated from what is on disk rather than maintained by hand, so the
+        # dropdown cannot list a version that was never published or miss one that was.
+        python3 "$GITHUB_ACTION_PATH/../../scripts/build_switcher.py" index site "$SITE_URL"
+
+        # Anyone landing on the bare site gets the newest release rather than a listing.
+        printf '<!doctype html><meta http-equiv="refresh" content="0; url=./stable/">\n' > site/index.html
+        # Jekyll would drop the _static and _sources directories Sphinx emits.
+        touch site/.nojekyll
+
+    - name: Update the archive branch
+      shell: bash
+      env:
+        TOKEN: ${{ inputs.token }}
+        REPO: ${{ github.repository }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        cd site
+        git init -q -b gh-pages
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A
+        git commit -q -m "docs: publish ${VERSION}"
+        # Force, onto a branch with no history by construction: the archive is a
+        # snapshot of what is online, and keeping every past snapshot would grow the
+        # repository by the size of the site on every release.
+        git push -q --force "https://x-access-token:${TOKEN}@github.com/${REPO}.git" gh-pages
+        rm -rf .git
+
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: site

--- a/.github/scripts/build_switcher.py
+++ b/.github/scripts/build_switcher.py
@@ -1,0 +1,85 @@
+"""Write the version-switcher index for the published documentation.
+
+The site is one directory per release plus a `stable` copy of the newest. This reads the
+directories that are actually there and writes the JSON the theme's dropdown fetches, so
+the dropdown cannot advertise a version that was never published, or omit one that was.
+
+Usage: build_switcher.py index <site-root> <base-url>
+       build_switcher.py canonical <version>
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+RELEASE_DIR = re.compile(r"\d{4}\.\d+\.\d+")
+
+
+def canonical_version(raw: str) -> str:
+    """The version as the installed package reports it.
+
+    Two spellings of one release are in play: the tag and `bump-my-version` write the
+    zero-padded CalVer month (2026.09.0), while PEP 440 normalisation strips the padding,
+    so `artefactual.__version__` -- and therefore the `version_match` the theme compares
+    against -- is 2026.9.0. The site must use the second, or the dropdown never marks the
+    version being read as the current one.
+    """
+    return ".".join(str(int(part)) for part in raw.split("."))
+
+
+def released_versions(site: Path) -> list[str]:
+    """The release directories under `site`, newest first.
+
+    Ordered numerically rather than lexically: sorting as strings puts 2026.10.0 before
+    2026.9.0, which would offer the wrong version as stable.
+    """
+    names = [d.name for d in site.iterdir() if d.is_dir() and RELEASE_DIR.fullmatch(d.name)]
+    return sorted(names, key=lambda n: [int(p) for p in n.split(".")], reverse=True)
+
+
+def switcher_entries(versions: list[str], base_url: str) -> list[dict[str, object]]:
+    """The dropdown's contents: the newest release as `stable`, then the older ones.
+
+    The newest appears once, under the `stable` URL rather than its own. Listing it twice
+    would give two entries the same `version`, and the theme marks the first one matching
+    the page's version as current -- so the duplicate is never reachable as "current" and
+    only makes the dropdown longer.
+    """
+    base = base_url.rstrip("/")
+    newest, older = versions[0], versions[1:]
+    entries: list[dict[str, object]] = [
+        {"name": f"{newest} (stable)", "version": newest, "url": f"{base}/stable/", "preferred": True}
+    ]
+    entries += [{"name": v, "version": v, "url": f"{base}/{v}/"} for v in older]
+    return entries
+
+
+def write_index(site_root: str, base_url: str) -> None:
+    site = Path(site_root)
+    versions = released_versions(site)
+    if not versions:
+        msg = f"no release directories under {site}; nothing to offer in the switcher"
+        raise SystemExit(msg)
+
+    entries = switcher_entries(versions, base_url)
+    # The keys the theme requires. It would have checked them itself by fetching the file at
+    # build time, which this site cannot rely on -- the file is written here, after the build.
+    missing = [e for e in entries if not {"version", "url"} <= set(e)]
+    if missing:
+        msg = f"switcher entries missing required keys: {missing}"
+        raise SystemExit(msg)
+
+    (site / "switcher.json").write_text(json.dumps(entries, indent=2) + "\n")
+    print(f"{len(versions)} version(s), stable = {versions[0]}")
+
+
+if __name__ == "__main__":
+    verb, *rest = sys.argv[1:]
+    if verb == "canonical":
+        print(canonical_version(*rest))
+    elif verb == "index":
+        write_index(*rest)
+    else:
+        msg = f"unknown verb {verb!r}; expected 'index' or 'canonical'"
+        raise SystemExit(msg)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,13 @@ on:
         description: Run the notebooks and publish the outputs they produce.
         type: boolean
         default: true
+      # Republishing a release means building its tag, not main: run
+      # `gh workflow run docs.yml --ref v2026.09.0 -f version=2026.09.0`. Dispatching from
+      # main with a released version here would overwrite that version's pages with main.
       version:
-        description: Version the built pages name. Empty means read it from the git tag.
+        description: Version the built pages name, as its tag spells it (e.g. 2026.09.0).
         type: string
-        default: ""
+        required: true
   workflow_call:
     inputs:
       deploy:
@@ -156,10 +159,15 @@ jobs:
           done
           exit $missing
 
+      # A plain artifact, not a Pages one: on a release the deploy job assembles this build
+      # into the archive of every previous release and publishes *that* tree. A pull request
+      # never reaches the deploy job, so for it this upload is only a build product.
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
+          name: site
           path: docs/_build/html
+          retention-days: 1
 
   deploy:
     # `inputs.deploy` alone, never `github.event_name`: in a called workflow the event is
@@ -173,7 +181,25 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write   # push the archive branch
+      pages: write
+      id-token: write
     steps:
+      # Only the scripts and the composite action are needed from the repository here;
+      # the built pages arrive as an artifact and the archive as a branch.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: false
+
+      - name: Assemble the versioned site
+        uses: ./.github/actions/publish-site
+        with:
+          version: ${{ inputs.version }}
+          site-url: https://artefactory.github.io/artefactual
+          token: ${{ github.token }}
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -384,15 +384,31 @@ jobs:
   # is the one docs-build uploaded in this same run, so the pages deployed are the ones
   # that gated the tag.
   docs-deploy:
-    needs: [docs-build, publish, github-release]
+    needs: [gate, docs-build, publish, github-release]
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     permissions:
+      contents: write   # push the archive branch
       pages: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: false
+
+      # docs.yml built the pages but did not deploy them: it is called with deploy: false so
+      # that nothing reaches the site until PyPI has the version. The assembly happens here
+      # instead, from the artifact that build uploaded in this same run.
+      - name: Assemble the versioned site
+        uses: ./.github/actions/publish-site
+        with:
+          version: ${{ needs.gate.outputs.version }}
+          site-url: https://artefactory.github.io/artefactual
+          token: ${{ github.token }}
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,9 @@ workflow run: chaining on the tag would leave the tag created and nothing built.
       -> publish-testpypi uploaded, then checked against the metadata the index serves
       -> publish          PyPI, held for a required reviewer
       -> github-release   the Release, once PyPI has the version
-      -> docs-deploy      the pages built above, published last
+      -> docs-deploy      the pages built above, added to the archive of previous
+                          releases under their own version directory, and published
+                          as the whole site
 
 Everything that can fail without leaving a trace runs before the tag; the tag is the last
 recoverable step, and the PyPI upload is the first irreversible one. So a failing test or a
@@ -122,6 +124,15 @@ The `pypi` environment has a required reviewer, so nothing reaches PyPI unattend
 release that should not go out is declined there; the tag is already created by then, and a
 tag is cheap to delete -- `git push origin :vYYYY.MM.PATCH` -- where a PyPI version is not
 reusable.
+
+The site keeps every release. Each one is published under its own version directory, with
+`stable/` a copy of the newest and a switcher in the navbar to move between them, so a
+reader pinned to an older version still has documentation that matches what they installed.
+The archive lives on the `gh-pages` branch because `actions/deploy-pages` replaces the whole
+site on every run; that branch is rewritten as a single commit each time, so the repository
+grows with the number of versions kept online rather than the number of deploys. At roughly
+20 MB a version, prune the oldest directories from `gh-pages` if the site approaches the
+1 GB Pages limit.
 
 Uploading before announcing is deliberate: a Release created first would advertise a
 version that a failed upload never produced, under a tag that cannot be reissued. The

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,21 @@ release = artefactual.__version__
 version = ".".join(release.split(".")[:2])
 _is_development_build = ".dev" in release
 
+# Where the published site lives. Fixed rather than derived, because the version switcher
+# has to name one URL that every version of the site agrees on: each release ships a copy
+# of this file, and they must all point at the same switcher.json, or an old page cannot
+# offer the versions released after it.
+SITE_URL = "https://artefactory.github.io/artefactual"
+
+# The site is one directory per release, so a page has to say which release it belongs to.
+html_baseurl = f"{SITE_URL}/{release}/" if not _is_development_build else SITE_URL
+
+# Just the project. The version belongs in the switcher, which names it once and makes it
+# navigable; repeating it here would also put the full local version
+# (2026.8.1.post1.dev36+j772a71f36.d20260911) in the site's most prominent label on every
+# build that is not a release.
+html_title = f"{project} documentation"
+
 # Extensions
 extensions = [
     "myst_parser",
@@ -174,6 +189,21 @@ html_baseurl = "https://artefactory.github.io/artefactual/"
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "github_url": "https://github.com/artefactory/artefactual",
+    # The released versions, and which one you are reading. `version_match` is the release
+    # string, matching the `version` key the deploy writes into switcher.json; on a
+    # development build it matches nothing, which leaves the dropdown listing the releases
+    # with none marked current -- correct, because an unreleased build is not among them.
+    "navbar_start": ["navbar-logo", "version-switcher"],
+    "switcher": {
+        "json_url": f"{SITE_URL}/switcher.json",
+        "version_match": release,
+    },
+    # The theme fetches json_url at build time and *warns* when it cannot be read, which
+    # -W turns into a failed build. That fetch would have to succeed before the deploy that
+    # publishes the file -- impossible for the release that introduces the switcher, and a
+    # network dependency in every build after it. The file's shape is asserted by the deploy
+    # that generates it instead.
+    "check_switcher": False,
     # The slot is empty by default; the theme puts downloads out of scope, so the component
     # is this repository's own.
     "article_header_end": ["notebook-buttons.html"],

--- a/tests/test_switcher.py
+++ b/tests/test_switcher.py
@@ -1,0 +1,111 @@
+"""The version switcher is generated during the deploy, where nothing else checks it.
+
+A wrong answer here is silent: the site still builds and still deploys, it just offers the
+wrong version as `stable` or drops a release out of the dropdown.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "build_switcher.py"
+
+_spec = importlib.util.spec_from_file_location("build_switcher", _SCRIPT)
+build_switcher = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(build_switcher)
+
+BASE = "https://artefactory.github.io/artefactual"
+
+
+def make_site(tmp_path: Path, names: list[str]) -> Path:
+    for name in names:
+        (tmp_path / name).mkdir()
+    return tmp_path
+
+
+def test_versions_are_ordered_numerically_not_lexically(tmp_path):
+    """2026.10.0 is newer than 2026.9.0, and string order says the opposite.
+
+    Sorted as strings, "2026.10.0" < "2026.9.0", so the first CalVer month to reach two
+    digits would publish the previous release as `stable`.
+    """
+    site = make_site(tmp_path, ["2026.8.1", "2026.9.0", "2026.10.0"])
+
+    assert build_switcher.released_versions(site) == ["2026.10.0", "2026.9.0", "2026.8.1"]
+
+
+def test_only_release_directories_are_offered(tmp_path):
+    """The site root also holds `stable`, `_static` and the redirecting index."""
+    site = make_site(tmp_path, ["2026.9.0", "stable", "_static", "dev"])
+    (site / "index.html").write_text("")
+
+    assert build_switcher.released_versions(site) == ["2026.9.0"]
+
+
+def test_the_newest_release_is_offered_once_as_stable(tmp_path):
+    """Two entries with one version would leave the duplicate unreachable as current."""
+    site = make_site(tmp_path, ["2026.8.1", "2026.9.0"])
+
+    entries = build_switcher.switcher_entries(build_switcher.released_versions(site), BASE)
+
+    assert [e["version"] for e in entries] == ["2026.9.0", "2026.8.1"]
+    assert entries[0]["url"] == f"{BASE}/stable/"
+    assert entries[0]["preferred"] is True
+    assert entries[1]["url"] == f"{BASE}/2026.8.1/"
+
+
+def test_every_entry_carries_the_keys_the_theme_requires(tmp_path):
+    """pydata-sphinx-theme reads `version` and `url`; it warns on an entry missing either.
+
+    It would check this itself by fetching the file at build time, which this site cannot
+    do -- the file is written by the deploy, after the build.
+    """
+    site = make_site(tmp_path, ["2026.8.0", "2026.8.1", "2026.9.0"])
+
+    entries = build_switcher.switcher_entries(build_switcher.released_versions(site), BASE)
+
+    assert all({"version", "url"} <= set(e) for e in entries)
+
+
+def test_an_empty_archive_is_refused(tmp_path):
+    """Publishing a switcher with no versions would render an empty dropdown."""
+    with pytest.raises(SystemExit):
+        build_switcher.write_index(str(tmp_path), BASE)
+
+
+def test_the_written_file_is_the_entries(tmp_path):
+    site = make_site(tmp_path, ["2026.9.0"])
+
+    build_switcher.write_index(str(site), BASE)
+
+    assert json.loads((site / "switcher.json").read_text()) == build_switcher.switcher_entries(["2026.9.0"], BASE)
+
+
+@pytest.mark.parametrize(
+    ("tagged", "installed"),
+    [("2026.09.0", "2026.9.0"), ("2026.08.1", "2026.8.1"), ("2026.10.0", "2026.10.0")],
+)
+def test_the_padded_tag_becomes_the_version_the_package_reports(tagged, installed):
+    """The tag and the installed package spell the same release differently.
+
+    `calver_format = "{YYYY}.{0M}"` pads the month, so the tag is v2026.09.0, while PEP 440
+    normalisation strips the zero and `artefactual.__version__` is 2026.9.0. conf.py takes
+    `version_match` from the package, so a directory named after the tag would never be
+    matched and the dropdown would mark nothing as current.
+    """
+    assert build_switcher.canonical_version(tagged) == installed
+
+
+def test_the_directory_name_matches_what_conf_py_compares_against(tmp_path):
+    """End to end: the gate's string in, an entry conf.py's version_match can match out."""
+    from_the_gate = "2026.09.0"
+
+    published_as = build_switcher.canonical_version(from_the_gate)
+    site = make_site(tmp_path, [published_as])
+    entries = build_switcher.switcher_entries(build_switcher.released_versions(site), BASE)
+
+    # conf.py sets version_match = artefactual.__version__, which for this release is:
+    version_match = "2026.9.0"
+    assert any(e["version"] == version_match for e in entries)


### PR DESCRIPTION
The site was one version at one URL, replaced on each release, and the version
it described
appeared nowhere a reader would look: navbar_start was never configured, so the
theme showed
no version component, and what rendered was Sphinx default html_title -- which
on any build
that is not a release reads "Artefactual
2026.8.1.post1.dev36+j772a71f36.d20260911
documentation".

That mattered the moment 2026.09.0 published, because it renamed epr()/wepr() to
EPR/WEPR.
Anyone pinned to 2026.08.1 opening the site now reads code that cannot work for
them, with
no route to the documentation matching what they installed.

Each release is now published under its own version directory, `stable/` is a
copy of the
newest, and the navbar carries the switcher every comparable project on this
theme uses
(numpy, pandas, scikit-learn). No `dev` deploy: the site still changes only when
a release
does.

`actions/deploy-pages` replaces the whole site on every run, so the previous
releases have
to be kept somewhere -- the `gh-pages` branch, rewritten as a single commit each
deploy, so
the repository grows with the number of versions online rather than the number
of times they
have been published.

switcher.json is generated from the directories actually present rather than
maintained by
hand, so it cannot advertise a version that was never published or omit one that
was. Its
ordering is numeric: sorted as strings, "2026.10.0" < "2026.9.0", and the first
CalVer month
to reach two digits would have published the previous release as stable. That is
a silent
failure -- the site still builds and still deploys -- so it is tested rather
than reviewed.

The theme own check on the switcher file is off. It fetches json_url at build
time and warns
when it cannot be read, which -W turns into a failed build: the file is written
by the deploy
that comes after, so the release introducing the switcher could never have
passed, and every
later build would depend on the network. The keys it would have checked are
asserted where
the file is generated.

A release is spelled two ways and the two must be reconciled or the dropdown
never
marks the version being read as current: the tag and the gate carry the
zero-padded CalVer
month (2026.09.0), while PEP 440 normalisation strips it, so the installed
package -- and
the `version_match` the theme compares against -- says 2026.9.0. The site is
written under
the package's spelling, canonicalised at the one boundary where the tag's form
enters.

Assembly is a composite action rather than steps in the deploy job, because two
callers
publish the site and they must assemble it identically: the release deploys
after PyPI has
the version, and docs.yml deploys on a manual dispatch. A caller that deployed
only its own
build would take every previous version offline, since deploy-pages replaces the
whole site.

