### PR TITLE
fix(ci): grant the called docs workflow the write it declares

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -370,7 +370,11 @@ jobs:
     needs: [gate, tests]
     if: needs.gate.outputs.release == 'true'
     permissions:
-      contents: read
+      # Write, although this call never deploys: the permissions a caller passes cap every
+      # job in the called workflow, and docs.yml's deploy job asks for write to push the
+      # archive branch. GitHub checks that cap when it loads the file, so `deploy: false`
+      # -- which decides at run time -- does not spare the workflow from failing to start.
+      contents: write
       pages: write
       id-token: write
     uses: ./.github/workflows/docs.yml


### PR DESCRIPTION
The release has not started since the version switcher landed: `release.yaml` fails to load, with

> The nested job 'deploy' is requesting 'contents: write', but is only allowed 'contents: read'.

The permissions a caller passes to a reusable workflow cap every job in it, and docs.yml's `deploy` job asks for `contents: write` to push the `gh-pages` archive. GitHub checks that cap when it loads the workflow file, so `deploy: false` -- which decides at run time -- does not spare the release from failing to start.

Nothing else changes: the release still calls docs.yml with `deploy: false` and publishes the site itself, after PyPI.
