### PR TITLE
docs(examples): remove the outputs that only echo the code above them

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,28 @@ nb_output_stderr = "warn"
 # ``{py:class}`~artefactual.scoring.WEPR` `` links to the page documenting it.
 nb_render_markdown_format = "myst"
 
+# Progress bars, off before any kernel starts. MyST-NB spawns the kernel from this process,
+# so it inherits what is set here -- which makes a local build behave as the release build
+# does without every contributor having to know the list. Each of these is read by a
+# different library, and any one of them left on puts a bar in the page.
+for _quiet in (
+    "HF_HUB_DISABLE_PROGRESS_BARS",
+    "HF_DATASETS_DISABLE_PROGRESS_BARS",
+    "TQDM_DISABLE",
+):
+    os.environ.setdefault(_quiet, "1")
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+
+# A progress bar under a kernel is an ipywidget, and its output carries a widget-view mime
+# the published page has no widget runtime to render. MyST-NB falls back to printing that
+# payload, so the page showed a line of raw JSON -- a model id and a schema version -- where
+# the bar had been. Dropping the mime makes it fall through to the plain-text alternative
+# the same output carries, which for a finished bar is nothing.
+nb_mime_priority_overrides = [
+    ("html", "application/vnd.jupyter.widget-view+json", None),
+    ("html", "application/vnd.jupyter.widget-state+json", None),
+]
+
 # A `{glue:text}` reads a value a cell computed, so a build that runs no cells has none to
 # read and warns once per reference -- which -W would turn into a failure of every pull
 # request. Suppressed only there. The release build executes, so a key that is misspelled

--- a/docs/examples/train_wepr.md
+++ b/docs/examples/train_wepr.md
@@ -113,11 +113,6 @@ features = EntropyTransformer(reduction="wepr").transform(logprobs)
 logprobs.shape, s_kj.shape, features.shape
 ```
 
-```{code-cell} ipython3
-# The same three steps, assembled: this is what `fit` runs, in this order.
-print(" -> ".join(name for name, _ in WEPR(k=K).steps))
-```
-
 ## Fit
 
 `WEPR()` returns the pipeline unfitted, so `fit` takes the batch lines directly and
@@ -220,7 +215,6 @@ search = GridSearchCV(WEPR(), {"parser__k": [5, 10, 15]}, cv=folds, scoring="roc
 search.fit(responses, y)
 for k, mean in zip(search.cv_results_["param_parser__k"], search.cv_results_["mean_test_score"], strict=True):
     print(f"  k={k:>2}: {mean:.2f}")
-print(f"best: k={search.best_params_['parser__k']}, ROC-AUC {search.best_score_:.2f}")
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Three outputs on the published pages said nothing the page did not already say.

`train_wepr` printed the pipeline's step names in a cell of its own, directly
under the
section that names those steps and explains what each contributes. The cell is
removed
rather than rewritten: it existed to display the pipeline, and the display was
the problem.
The same cell's neighbour restated the best `k` from a grid search whose per-`k`
scores it
had just printed in full, one line above.

`train_wepr_bertjudge` showed a line of raw JSON -- a schema version and a model
id --
where a progress bar had been. A bar under a kernel is an ipywidget, and its
output carries
a widget-view mime that a published page has no runtime to render; MyST-NB
prints the
payload instead. The bars are now switched off before any kernel starts --
MyST-NB spawns it from the Sphinx
process, so `conf.py` setting the environment covers a local build and the
release build
alike. The widget mimes are dropped for the html builder as well, so a bar from
a library
that reads none of those variables still cannot reach the page.

That removed more than the JSON. A notebook with widgets also emits a
widget-state script
and pulls require.js and the widget bundle from a CDN into the page, which the
site neither
needs nor should depend on; with no widgets, neither appears. The cell now shows
what it
actually printed -- the count of verdicts it wrote -- which the bar had been
sitting on top
of.

